### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,27 @@
+name: .NET
+
+on:
+  push:
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.yml'
+      - '**.yaml'
+      - tests/**
+  pull_request:
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.yml'
+      - '**.yaml'
+      - tests/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+    - run: dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build

--- a/Kestrun.sln
+++ b/Kestrun.sln
@@ -4,17 +4,23 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun", "src\Kestrun\Kestrun.csproj", "{2DC5C603-9907-9D28-5F02-DC85B2C9099B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KestrunLib.Tests", "tests\KestrunLib.Tests\KestrunLib.Tests.csproj", "{9370B831-8AFA-4D0B-9A82-6CA24A331A18}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2DC5C603-9907-9D28-5F02-DC85B2C9099B}.Release|Any CPU.Build.0 = Release|Any CPU
+{9370B831-8AFA-4D0B-9A82-6CA24A331A18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9370B831-8AFA-4D0B-9A82-6CA24A331A18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9370B831-8AFA-4D0B-9A82-6CA24A331A18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9370B831-8AFA-4D0B-9A82-6CA24A331A18}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@
 ╚═╝  ╚═╝╚══════╝╚══════╝   ╚═╝   ╚═╝ ╚═╝  ╚═════╝ ╚═╝  ╚═══╝
               Kestrun — PowerShell brains. Kestrel speed.
 ```
+
+## Running Tests
+
+Tests are written with `xUnit` under `tests/KestrunLib.Tests`. To execute them locally:
+
+```bash
+dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj
+```
+
+A GitHub Actions workflow runs these tests automatically on every push and pull request.

--- a/tests/KestrunLib.Tests/BuildErrorTests.cs
+++ b/tests/KestrunLib.Tests/BuildErrorTests.cs
@@ -1,0 +1,42 @@
+using KestrumLib;
+using System.Management.Automation;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class BuildErrorTests
+{
+    [Fact]
+    public void Text_ReturnsFormattedErrors()
+    {
+        using PowerShell ps = PowerShell.Create();
+        ps.AddScript("Write-Error 'boom'");
+        ps.Invoke();
+        string text = BuildError.Text(ps);
+        Assert.Contains("boom", text);
+    }
+
+    [Fact]
+    public async Task ResponseAsync_WritesToContext()
+    {
+        using PowerShell ps = PowerShell.Create();
+        ps.AddScript("Write-Error 'oops'");
+        ps.Invoke();
+        var ctx = new DefaultHttpContext();
+        await BuildError.ResponseAsync(ctx, ps);
+        ctx.Response.Body.Seek(0, System.IO.SeekOrigin.Begin);
+        string body = new StreamReader(ctx.Response.Body).ReadToEnd();
+        Assert.Contains("oops", body);
+    }
+
+    [Fact]
+    public void Result_ReturnsIResult()
+    {
+        using PowerShell ps = PowerShell.Create();
+        ps.AddScript("Write-Error 'uh'");
+        ps.Invoke();
+        var result = BuildError.Result(ps);
+        Assert.NotNull(result);
+    }
+}

--- a/tests/KestrunLib.Tests/CompilationErrorExceptionTests.cs
+++ b/tests/KestrunLib.Tests/CompilationErrorExceptionTests.cs
@@ -1,0 +1,25 @@
+using KestrumLib;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using Xunit;
+
+public class CompilationErrorExceptionTests
+{
+    private static Diagnostic MakeDiag(string msg, DiagnosticSeverity severity)
+    {
+        var descriptor = new DiagnosticDescriptor("ID", "Title", msg, "Cat", severity, true);
+        return Diagnostic.Create(descriptor, Location.None);
+    }
+
+    [Fact]
+    public void GetErrorsAndWarnings_Work()
+    {
+        var diags = ImmutableArray.Create(
+            MakeDiag("err", DiagnosticSeverity.Error),
+            MakeDiag("warn", DiagnosticSeverity.Warning));
+        var ex = new CompilationErrorException("bad", diags);
+        Assert.Single(ex.GetErrors());
+        Assert.Single(ex.GetWarnings());
+        Assert.Contains("err", ex.GetDetailedErrorMessage());
+    }
+}

--- a/tests/KestrunLib.Tests/GlobalVariablesTests.cs
+++ b/tests/KestrunLib.Tests/GlobalVariablesTests.cs
@@ -1,0 +1,49 @@
+using KestrumLib;
+using System.Collections.Generic;
+using Xunit;
+
+public class GlobalVariablesTests
+{
+    [Fact]
+    public void Define_And_TryGet_Works()
+    {
+        GlobalVariables.Remove("foo");
+        GlobalVariables.Define("foo", new List<int> { 1,2 });
+        Assert.True(GlobalVariables.TryGet("foo", out List<int>? val));
+        Assert.Equal(2, val?.Count);
+    }
+
+    [Fact]
+    public void Remove_RespectsReadOnly()
+    {
+        GlobalVariables.Define("ro", new object(), readOnly: true);
+        Assert.False(GlobalVariables.Remove("ro"));
+    }
+
+    [Fact]
+    public void UpdateValue_Works()
+    {
+        GlobalVariables.Define("upd", new List<int>());
+        GlobalVariables.UpdateValue("upd", new List<int>{1});
+        var obj = GlobalVariables.Get("upd") as List<int>;
+        Assert.Single(obj!);
+    }
+
+    [Fact]
+    public void Snapshot_And_GetAllValues_Work()
+    {
+        GlobalVariables.Define("snap", "val");
+        var snap = GlobalVariables.Snapshot();
+        Assert.True(snap.ContainsKey("snap"));
+        var vals = GlobalVariables.GetAllValues();
+        Assert.Equal("val", vals["snap"]);
+    }
+
+    [Fact]
+    public void GetTypeAndReadOnly_Work()
+    {
+        GlobalVariables.Define("t", new object(), readOnly: true);
+        Assert.True(GlobalVariables.IsReadOnly("t"));
+        Assert.Equal(typeof(object), GlobalVariables.GetTypeOf("t"));
+    }
+}

--- a/tests/KestrunLib.Tests/HttpVerbExtensionsTests.cs
+++ b/tests/KestrunLib.Tests/HttpVerbExtensionsTests.cs
@@ -1,0 +1,14 @@
+using KestrumLib;
+using Xunit;
+
+public class HttpVerbExtensionsTests
+{
+    [Theory]
+    [InlineData(HttpVerb.Get, "GET")]
+    [InlineData(HttpVerb.Post, "POST")]
+    [InlineData(HttpVerb.Delete, "DELETE")]
+    public void ToMethodString_ReturnsUpperCase(HttpVerb verb, string expected)
+    {
+        Assert.Equal(expected, verb.ToMethodString());
+    }
+}

--- a/tests/KestrunLib.Tests/KestrunHostScriptTests.cs
+++ b/tests/KestrunLib.Tests/KestrunHostScriptTests.cs
@@ -1,0 +1,29 @@
+using KestrumLib;
+using Xunit;
+
+public class KestrunHostScriptTests
+{
+    [Fact]
+    public void IsCSharpScriptValid_ReturnsTrueForValid()
+    {
+        var host = new KestrunHost();
+        bool valid = host.IsCSharpScriptValid("System.Console.WriteLine(\"hi\");");
+        Assert.True(valid);
+    }
+
+    [Fact]
+    public void IsCSharpScriptValid_ReturnsFalseForInvalid()
+    {
+        var host = new KestrunHost();
+        bool valid = host.IsCSharpScriptValid("System.Console.Writeline(\"hi\");");
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public void GetCSharpScriptErrors_ReturnsMessage()
+    {
+        var host = new KestrunHost();
+        var msg = host.GetCSharpScriptErrors("System.Console.Writeline(\"hi\");");
+        Assert.NotNull(msg);
+    }
+}

--- a/tests/KestrunLib.Tests/KestrunLib.Tests.csproj
+++ b/tests/KestrunLib.Tests/KestrunLib.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kestrun/Kestrun.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/KestrunLib.Tests/KestrunRequestTests.cs
+++ b/tests/KestrunLib.Tests/KestrunRequestTests.cs
@@ -1,0 +1,28 @@
+using KestrumLib;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class KestrunRequestTests
+{
+    [Fact]
+    public async Task NewRequest_ReadsContext()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = "POST";
+        ctx.Request.Path = "/foo";
+        ctx.Request.QueryString = new QueryString("?a=1");
+        ctx.Request.Headers["X-Test"] = "yes";
+        var bodyBytes = Encoding.UTF8.GetBytes("data");
+        ctx.Request.Body = new MemoryStream(bodyBytes);
+
+        var req = await KestrunRequest.NewRequest(ctx);
+        Assert.Equal("POST", req.Method);
+        Assert.Equal("/foo", req.Path);
+        Assert.Equal("1", req.Query["a"]);
+        Assert.Equal("yes", req.Headers["X-Test"]);
+        Assert.Equal("data", req.Body);
+    }
+}

--- a/tests/KestrunLib.Tests/KestrunResponseTests.cs
+++ b/tests/KestrunLib.Tests/KestrunResponseTests.cs
@@ -1,0 +1,125 @@
+using KestrumLib;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+public class KestrunResponseTests
+{
+    private static KestrunResponse NewRes() =>
+        new(new KestrunRequest
+        {
+            Method = "GET",
+            Path = "/",
+            Query = new(),
+            Headers = new(),
+            Body = string.Empty
+        });
+
+    [Fact]
+    public void WriteTextResponse_SetsFields()
+    {
+        var res = NewRes();
+        res.WriteTextResponse("hello", StatusCodes.Status200OK);
+        Assert.Equal("hello", res.Body);
+        Assert.Equal(StatusCodes.Status200OK, res.StatusCode);
+        Assert.Contains("text/plain", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteJsonResponse_SetsFields()
+    {
+        var res = NewRes();
+        res.WriteJsonResponse(new { a = 1 });
+        Assert.Contains("\"a\": 1", res.Body as string);
+        Assert.Contains("application/json", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteYamlResponse_SetsFields()
+    {
+        var res = NewRes();
+        res.WriteYamlResponse(new { a = 1 });
+        Assert.Contains("a: 1", res.Body as string);
+        Assert.Contains("application/yaml", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteXmlResponse_SetsFields()
+    {
+        var res = NewRes();
+        res.WriteXmlResponse(new { a = 1 });
+        Assert.Contains("<a>1</a>", res.Body as string);
+        Assert.Contains("application/xml", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteBinaryResponse_SetsFields()
+    {
+        var res = NewRes();
+        res.WriteBinaryResponse([1,2,3]);
+        Assert.Equal(new byte[]{1,2,3}, res.Body as byte[]);
+        Assert.Equal("application/octet-stream", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteStreamResponse_SetsFields()
+    {
+        var res = NewRes();
+        using var ms = new MemoryStream([1,2]);
+        res.WriteStreamResponse(ms);
+        Assert.Equal(ms, res.Body);
+        Assert.Equal("application/octet-stream", res.ContentType);
+    }
+
+    [Fact]
+    public void WriteRedirectResponse_SetsHeaders()
+    {
+        var res = NewRes();
+        res.WriteRedirectResponse("/foo", "go");
+        Assert.Equal("/foo", res.RedirectUrl);
+        Assert.Equal("go", res.Body);
+        Assert.Equal("/foo", res.Headers["Location"]);
+    }
+
+    [Fact]
+    public void WriteErrorResponse_FromMessage()
+    {
+        var res = NewRes();
+        res.WriteErrorResponse("oops");
+        Assert.Equal(StatusCodes.Status500InternalServerError, res.StatusCode);
+        Assert.NotNull(res.Body);
+    }
+
+    [Fact]
+    public void WriteErrorResponse_FromException()
+    {
+        var res = NewRes();
+        res.WriteErrorResponse(new System.Exception("bad"));
+        Assert.Equal(StatusCodes.Status500InternalServerError, res.StatusCode);
+        Assert.NotNull(res.Body);
+    }
+
+    [Fact]
+    public async Task ApplyTo_WritesHttpResponse()
+    {
+        var res = NewRes();
+        res.WriteTextResponse("hi");
+        var ctx = new DefaultHttpContext();
+        await res.ApplyTo(ctx.Response);
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        var text = new StreamReader(ctx.Response.Body).ReadToEnd();
+        Assert.Equal("hi", text);
+        Assert.Equal("text/plain; charset=utf-8", ctx.Response.ContentType);
+    }
+
+    [Theory]
+    [InlineData("text/plain", true)]
+    [InlineData("application/json", true)]
+    [InlineData("application/octet-stream", false)]
+    public void IsTextBasedContentType_Works(string type, bool expected)
+    {
+        Assert.Equal(expected, KestrunResponse.IsTextBasedContentType(type));
+    }
+}

--- a/tests/KestrunLib.Tests/XmlUtilTests.cs
+++ b/tests/KestrunLib.Tests/XmlUtilTests.cs
@@ -1,0 +1,53 @@
+using KestrumLib;
+using System.Collections;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Xunit;
+
+public class XmlUtilTests
+{
+    [Fact]
+    public void ToXml_Null_ReturnsNilElement()
+    {
+        var elem = XmlUtil.ToXml("Value", null);
+        Assert.Equal("Value", elem.Name);
+        Assert.Equal("true", elem.Attribute(XName.Get("nil", "http://www.w3.org/2001/XMLSchema-instance"))?.Value);
+    }
+
+    [Fact]
+    public void ToXml_Primitive_ReturnsElementWithValue()
+    {
+        var elem = XmlUtil.ToXml("Number", 42);
+        Assert.Equal("42", elem.Value);
+    }
+
+    [Fact]
+    public void ToXml_Dictionary_ReturnsNestedElements()
+    {
+        var dict = new Hashtable { { "A", 1 }, { "B", 2 } };
+        var elem = XmlUtil.ToXml("Dict", dict);
+        Assert.Equal("1", elem.Element("A")?.Value);
+        Assert.Equal("2", elem.Element("B")?.Value);
+    }
+
+    [Fact]
+    public void ToXml_List_ReturnsItemElements()
+    {
+        var list = new List<int> { 1, 2 };
+        var elem = XmlUtil.ToXml("List", list);
+        Assert.Collection(elem.Elements(), e => Assert.Equal("1", e.Value), e => Assert.Equal("2", e.Value));
+    }
+
+    private class Sample
+    {
+        public string Name { get; set; } = "Foo";
+    }
+
+    [Fact]
+    public void ToXml_Object_UsesProperties()
+    {
+        var sample = new Sample();
+        var elem = XmlUtil.ToXml("Sample", sample);
+        Assert.Equal("Foo", elem.Element("Name")?.Value);
+    }
+}

--- a/tests/KestrunLib.Tests/YamlHelperTests.cs
+++ b/tests/KestrunLib.Tests/YamlHelperTests.cs
@@ -1,0 +1,34 @@
+using KestrumLib;
+using System.Collections;
+using System.Management.Automation;
+using Xunit;
+
+public class YamlHelperTests
+{
+    [Fact]
+    public void ToYaml_SerializesObject()
+    {
+        var ht = new Hashtable { { "name", "foo" }, { "value", 1 } };
+        var yaml = YamlHelper.ToYaml(ht);
+        Assert.Contains("name: foo", yaml);
+        Assert.Contains("value: 1", yaml);
+    }
+
+    [Fact]
+    public void FromYamlToHashtable_RoundTrip()
+    {
+        string yaml = "name: foo\nvalue: 1";
+        var ht = YamlHelper.FromYamlToHashtable(yaml);
+        Assert.Equal("foo", ht["name"]);
+        Assert.Equal(1, (int)(ht["value"]));
+    }
+
+    [Fact]
+    public void FromYamlToPSCustomObject_RoundTrip()
+    {
+        string yaml = "name: foo\nvalue: 1";
+        var obj = YamlHelper.FromYamlToPSCustomObject(yaml);
+        Assert.Equal("foo", obj.Members["name"].Value);
+        Assert.Equal(1, (int)obj.Members["value"].Value);
+    }
+}


### PR DESCRIPTION
## Summary
- expand unit test coverage for library classes
- add workflow to run `dotnet test`
- document how to run tests locally

## Testing
- `dotnet test tests/KestrunLib.Tests/KestrunLib.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879861b19b48320a7c25a94281d28ea