### PR TITLE
Add tests for internal utilities

### DIFF
--- a/tests/CSharp.Tests/Kestrun.Tests/HttpVerbExtensionsTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/HttpVerbExtensionsTests.cs
@@ -10,6 +10,11 @@ public class HttpVerbExtensionsTests
     [InlineData(HttpVerb.Get, "GET")]
     [InlineData(HttpVerb.Post, "POST")]
     [InlineData(HttpVerb.Delete, "DELETE")]
+    [InlineData(HttpVerb.Head, "HEAD")]
+    [InlineData(HttpVerb.Put, "PUT")]
+    [InlineData(HttpVerb.Patch, "PATCH")]
+    [InlineData(HttpVerb.Options, "OPTIONS")]
+    [InlineData(HttpVerb.Trace, "TRACE")]
     public void ToMethodString_ReturnsUpperCase(HttpVerb verb, string expected)
     {
         Assert.Equal(expected, verb.ToMethodString());

--- a/tests/CSharp.Tests/Kestrun.Tests/PowerShellModuleLocatorTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/PowerShellModuleLocatorTests.cs
@@ -1,0 +1,30 @@
+using Kestrun.Utilities;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+#pragma warning disable CA1050 // Declare types in namespaces
+public class PowerShellModuleLocatorTests
+#pragma warning restore CA1050 // Declare types in namespaces
+{
+    [Fact]
+    public void FindFileUpwards_FindsFile()
+    {
+        var root = Directory.CreateTempSubdirectory();
+        try
+        {
+            var nested = Directory.CreateDirectory(Path.Combine(root.FullName, "a", "b"));
+            var targetDir = Directory.CreateDirectory(Path.Combine(root.FullName, "a"));
+            var file = Path.Combine(targetDir.FullName, "test.txt");
+            File.WriteAllText(file, "data");
+
+            var method = typeof(PowerShellModuleLocator).GetMethod("FindFileUpwards", BindingFlags.NonPublic | BindingFlags.Static)!;
+            string? found = (string?)method.Invoke(null, new object[] { nested.FullName, Path.Combine("..", "test.txt") });
+            Assert.Equal(Path.GetFullPath(file), Path.GetFullPath(found!));
+        }
+        finally
+        {
+            root.Delete(true);
+        }
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/RegexUtilsTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/RegexUtilsTests.cs
@@ -1,0 +1,33 @@
+using Kestrun.Utilities;
+using System.Reflection;
+using Xunit;
+
+#pragma warning disable CA1050 // Declare types in namespaces
+public class RegexUtilsTests
+#pragma warning restore CA1050 // Declare types in namespaces
+{
+    private static bool InvokeIsGlobMatch(string input, string pattern, bool ignoreCase = true)
+    {
+        var asm = typeof(SecurityUtilities).Assembly;
+        var t = asm.GetType("Kestrun.Utilities.RegexUtils")!;
+        var method = t.GetMethod("IsGlobMatch", BindingFlags.Public | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, new object[] { input, pattern, ignoreCase })!;
+    }
+
+    [Theory]
+    [InlineData("foo.txt", "*.txt", true)]
+    [InlineData("foo.TXT", "*.txt", true)]
+    [InlineData("bar.log", "*.txt", false)]
+    [InlineData("abc", "a?c", true)]
+    public void IsGlobMatch_Works(string input, string pattern, bool expected)
+    {
+        Assert.Equal(expected, InvokeIsGlobMatch(input, pattern));
+    }
+
+    [Fact]
+    public void IsGlobMatch_CaseSensitive_Works()
+    {
+        Assert.True(InvokeIsGlobMatch("abc", "ABC", ignoreCase: true));
+        Assert.False(InvokeIsGlobMatch("abc", "ABC", ignoreCase: false));
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/SecurityUtilitiesTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/SecurityUtilitiesTests.cs
@@ -1,0 +1,36 @@
+using Kestrun.Utilities;
+using Xunit;
+
+#pragma warning disable CA1050 // Declare types in namespaces
+public class SecurityUtilitiesTests
+#pragma warning restore CA1050 // Declare types in namespaces
+{
+    [Fact]
+    public void FixedTimeEquals_ByteArrays_Equal_ReturnsTrue()
+    {
+        byte[] a = { 1, 2, 3 };
+        byte[] b = { 1, 2, 3 };
+        Assert.True(SecurityUtilities.FixedTimeEquals(a, b));
+    }
+
+    [Fact]
+    public void FixedTimeEquals_ByteArrays_Different_ReturnsFalse()
+    {
+        byte[] a = { 1, 2, 3 };
+        byte[] b = { 1, 2, 4 };
+        Assert.False(SecurityUtilities.FixedTimeEquals(a, b));
+    }
+
+    [Fact]
+    public void FixedTimeEquals_Strings_Equal_ReturnsTrue()
+    {
+        Assert.True(SecurityUtilities.FixedTimeEquals("abc", "abc"));
+    }
+
+    [Fact]
+    public void FixedTimeEquals_Strings_Null_ReturnsFalse()
+    {
+        Assert.False(SecurityUtilities.FixedTimeEquals(null, "abc"));
+        Assert.False(SecurityUtilities.FixedTimeEquals("abc", null));
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for `RegexUtils.IsGlobMatch` using reflection
- add tests for private search helper in `PowerShellModuleLocator`

## Testing
- `dotnet build tests/CSharp.Tests/Kestrun.Tests/KestrunTests.csproj -c Debug`
- `dotnet test tests/CSharp.Tests/Kestrun.Tests/KestrunTests.csproj --no-build --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68868ff8b2888320b6745063bba670c1