### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: .NET and PowerShell Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Kestrun/Kestrun/security/code-scanning/1](https://github.com/Kestrun/Kestrun/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only build and test code (no steps require write access to the repository or issues), the minimal permission of `contents: read` is sufficient. This should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
