### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clam-av.yml
+++ b/.github/workflows/clam-av.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: AV scan (ClamAV)
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Kestrun/Kestrun/security/code-scanning/29](https://github.com/Kestrun/Kestrun/security/code-scanning/29)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply to a specific job). The minimal required permission for most workflows is `contents: read`, which allows the workflow to read repository contents but not modify them. Since the workflow does not appear to require any write access to repository contents, and only uploads an artifact (which does not require write access to repository contents), setting `contents: read` at the root level is sufficient and adheres to the principle of least privilege.

You should add the following block immediately after the `name:` line and before the `on:` block in `.github/workflows/clam-av.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
