### PR TITLE
docs(tutorial/scheduling): complete scheduler tutorials, topic, examples, and tests (Fixes #109)

### DIFF
--- a/docs/_includes/examples/pwsh/12.1-Scheduling-Quickstart.ps1
+++ b/docs/_includes/examples/pwsh/12.1-Scheduling-Quickstart.ps1
@@ -1,0 +1,59 @@
+﻿<#
+    Scheduling Quickstart Script
+    Demonstrates enabling the SchedulerService and registering jobs
+    with both PowerShell and C# code. Also exposes a small route to
+    inspect the live schedule report and a counter route.
+    FileName: 12.1-Scheduling-Quickstart.ps1
+#>
+param(
+    [int]$Port = 5000,
+    [IPAddress]$IPAddress = [IPAddress]::Loopback
+)
+
+## 1. Logging
+New-KrLogger |
+    Add-KrSinkConsole |
+    Register-KrLogger -Name 'console' -SetAsDefault
+
+## 2. Server
+New-KrServer -Name 'Scheduling Demo'
+
+## 3. Listener
+Add-KrEndpoint -Port $Port -IPAddress $IPAddress
+
+## 4. Runtime + Scheduler
+Add-KrPowerShellRuntime
+Add-KrScheduling -MaxRunspaces 4
+
+## 5. Shared state (for demo route)
+Set-KrSharedState -Name 'Visits' -Value @{ Count = 0 }
+
+## 6. Apply configuration
+Enable-KrConfiguration
+
+## 7. Register scheduled jobs
+
+# (A) PowerShell heartbeat every 10s, run immediately once
+Register-KrSchedule -Name 'heartbeat-ps' -Interval '00:00:10' -RunImmediately -ScriptBlock {
+    Write-KrLog -Level Information -Message '💓 Heartbeat (PS) at {0:O}' -Values $([DateTimeOffset]::UtcNow)
+}
+
+# (B) C# heartbeat every 15s
+Register-KrSchedule -Name 'heartbeat-cs' -Interval '00:00:15' -Language CSharp -Code 'Serilog.Log.Information("💓 Heartbeat (C#) at {0:O}", DateTimeOffset.UtcNow);'
+
+## 8. Routes
+
+# /visit increments a shared counter
+Add-KrMapRoute -Verbs Get -Pattern '/visit' -ScriptBlock {
+    $Visits['Count']++
+    Write-KrTextResponse -InputObject ('Visits now: {0}' -f $Visits['Count']) -StatusCode 200
+}
+
+# /schedule/report returns the aggregated report
+Add-KrMapRoute -Verbs Get -Pattern '/schedule/report' -ScriptBlock {
+    $report = Get-KrScheduleReport
+    Write-KrJsonResponse -InputObject $report -StatusCode 200
+}
+
+## 9. Start server
+Start-KrServer -CloseLogsOnExit

--- a/docs/_includes/examples/pwsh/12.2-Scheduling-Cron.ps1
+++ b/docs/_includes/examples/pwsh/12.2-Scheduling-Cron.ps1
@@ -1,0 +1,45 @@
+﻿<#
+    Scheduling Cron Example
+    Demonstrates CRON-based jobs (seconds precision) with PowerShell and C#.
+    FileName: 12.2-Scheduling-Cron.ps1
+#>
+param(
+    [int]$Port = 5000,
+    [IPAddress]$IPAddress = [IPAddress]::Loopback
+)
+
+## 1. Logging
+New-KrLogger | Add-KrSinkConsole | Register-KrLogger -Name 'console' -SetAsDefault
+
+## 2. Server
+New-KrServer -Name 'Scheduling Cron Demo'
+
+## 3. Listener
+Add-KrEndpoint -Port $Port -IPAddress $IPAddress
+
+## 4. Runtime + Scheduler
+Add-KrPowerShellRuntime
+Add-KrScheduling -MaxRunspaces 2
+
+## 5. Apply configuration
+Enable-KrConfiguration
+
+## 6. CRON jobs
+
+# (A) PowerShell job every 10 seconds, run once immediately
+Register-KrSchedule -Name 'cron-ps' -Cron '*/10 * * * * *' -RunImmediately -ScriptBlock {
+    Write-KrLog -Level Information -Message '⏰ cron-ps fired at {0:O}' -Values $([DateTimeOffset]::UtcNow)
+}
+
+# (B) C# job every 15 seconds, run once immediately
+Register-KrSchedule -Name 'cron-cs' -Cron '*/15 * * * * *' -Language CSharp -RunImmediately -Code 'Serilog.Log.Information("⏰ cron-cs fired at {0:O}", DateTimeOffset.UtcNow);'
+
+## 7. Routes
+Add-KrMapRoute -Verbs Get -Pattern '/schedule/report' -ScriptBlock {
+    $report = Get-KrScheduleReport
+    Write-KrJsonResponse -InputObject $report -StatusCode 200
+}
+
+## 8. Start
+Start-KrServer -CloseLogsOnExit
+

--- a/docs/_includes/examples/pwsh/12.3-Scheduling-Report.ps1
+++ b/docs/_includes/examples/pwsh/12.3-Scheduling-Report.ps1
@@ -36,8 +36,13 @@ Add-KrMapRoute -Verbs Get -Pattern '/schedule/report' -ScriptBlock {
     Write-KrLog -Level Information -Message "Requested timezone: $tz"
 
     if ($tz) {
-        [void][TimeZoneInfo]::FindSystemTimeZoneById($tz)
-        $report = Get-KrScheduleReport -TimeZoneId $tz
+        try {
+            [void][TimeZoneInfo]::FindSystemTimeZoneById($tz)
+            $report = Get-KrScheduleReport -TimeZoneId $tz
+        } catch {
+            Write-KrLog -Level Warning -Message "Invalid timezone ID '$tz' provided. Falling back to UTC."
+            $report = Get-KrScheduleReport
+        }
     } else {
         $report = Get-KrScheduleReport
     }

--- a/docs/_includes/examples/pwsh/12.3-Scheduling-Report.ps1
+++ b/docs/_includes/examples/pwsh/12.3-Scheduling-Report.ps1
@@ -1,0 +1,49 @@
+﻿<#
+    Scheduling Report Example
+    Demonstrates exposing a report endpoint with optional timezone.
+    FileName: 12.3-Scheduling-Report.ps1
+#>
+param(
+    [int]$Port = 5000,
+    [IPAddress]$IPAddress = [IPAddress]::Loopback
+)
+
+## 1. Logging
+New-KrLogger | Add-KrSinkConsole | Register-KrLogger -Name 'console' -SetAsDefault
+
+## 2. Server
+New-KrServer -Name 'Scheduling Report Demo'
+
+## 3. Listener
+Add-KrEndpoint -Port $Port -IPAddress $IPAddress
+
+## 4. Runtime + Scheduler
+Add-KrPowerShellRuntime
+Add-KrScheduling
+
+## 5. Apply configuration
+Enable-KrConfiguration
+
+## 6. Register a couple of jobs so the report has content
+Register-KrSchedule -Name 'rep-ps' -Interval '00:00:05' -RunImmediately -ScriptBlock {
+    Write-KrLog -Level Debug -Message 'rep-ps ran at {0:O}' -Values $([DateTimeOffset]::UtcNow)
+}
+Register-KrSchedule -Name 'rep-cs' -Interval '00:00:07' -Language CSharp -RunImmediately -Code 'Serilog.Log.Debug("rep-cs ran at {0:O}", DateTimeOffset.UtcNow);'
+
+## 7. Report route (supports ?tz=<TimeZoneId>)
+Add-KrMapRoute -Verbs Get -Pattern '/schedule/report' -ScriptBlock {
+    $tz = Get-KrRequestQuery -Name 'tz'
+    Write-KrLog -Level Information -Message "Requested timezone: $tz"
+
+    if ($tz) {
+        [void][TimeZoneInfo]::FindSystemTimeZoneById($tz)
+        $report = Get-KrScheduleReport -TimeZoneId $tz
+    } else {
+        $report = Get-KrScheduleReport
+    }
+
+    Write-KrJsonResponse -InputObject $report -StatusCode 200
+}
+
+## 8. Start
+Start-KrServer -CloseLogsOnExit

--- a/docs/pwsh/tutorial/12.scheduling/1.Scheduling-Quickstart.md
+++ b/docs/pwsh/tutorial/12.scheduling/1.Scheduling-Quickstart.md
@@ -1,0 +1,73 @@
+---
+title: Scheduling Quickstart
+parent: Scheduler
+nav_order: 1
+---
+
+# Scheduling Quickstart
+
+Enable the scheduler, register a couple of jobs, and expose diagnostic routes.
+
+## Full source
+
+File: [`pwsh/tutorial/examples/12.1-Scheduling-Quickstart.ps1`][12.1-Scheduling-Quickstart.ps1]
+
+```powershell
+{% include examples/pwsh/12.1-Scheduling-Quickstart.ps1 %}
+```
+
+## Steps
+
+1. Logging — console sink for visibility
+2. Server — create host and listener (loopback:5000)
+3. Runtime — add PowerShell runtime and scheduler (4 runspaces)
+4. Shared state — global `Visits` counter injected into runspaces
+5. Enable configuration — finalize the pipeline
+6. Jobs — two heartbeats (PS every 10s; C# every 15s)
+7. Routes — `/visit` increments counter; `/schedule/report` returns a JSON report
+8. Start — run the server; observe log heartbeats and query endpoints
+
+## Try it
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:5000/visit -SkipCertificateCheck
+Invoke-RestMethod http://127.0.0.1:5000/schedule/report -SkipCertificateCheck | ConvertTo-Json -Depth 4
+```
+
+You should see job entries similar to:
+
+```json
+{
+  "generatedAt": "2025-10-03T12:00:00Z",
+  "jobs": [
+    { "name": "heartbeat-ps", "lastRunAt": "…", "nextRunAt": "…", "isSuspended": false },
+    { "name": "heartbeat-cs", "lastRunAt": "…", "nextRunAt": "…", "isSuspended": false }
+  ]
+}
+```
+
+## Cmdlet references
+
+- [Add-KrScheduling][Add-KrScheduling]
+- [Register-KrSchedule][Register-KrSchedule]
+- [Get-KrScheduleReport][Get-KrScheduleReport]
+- [Get-KrScheduleSnapshot][Get-KrScheduleSnapshot]
+- [Suspend-KrSchedule][Suspend-KrSchedule]
+- [Resume-KrSchedule][Resume-KrSchedule]
+
+---
+
+### Next
+
+{: .fs-4 .fw-500}
+
+Continue to [Scheduling with CRON][Next]
+
+[12.1-Scheduling-Quickstart.ps1]: /pwsh/tutorial/examples/12.1-Scheduling-Quickstart.ps1
+[Add-KrScheduling]: /pwsh/cmdlets/Add-KrScheduling
+[Register-KrSchedule]: /pwsh/cmdlets/Register-KrSchedule
+[Get-KrScheduleReport]: /pwsh/cmdlets/Get-KrScheduleReport
+[Get-KrScheduleSnapshot]: /pwsh/cmdlets/Get-KrScheduleSnapshot
+[Suspend-KrSchedule]: /pwsh/cmdlets/Suspend-KrSchedule
+[Resume-KrSchedule]: /pwsh/cmdlets/Resume-KrSchedule
+[Next]: ./2.Scheduling-Cron

--- a/docs/pwsh/tutorial/12.scheduling/2.Scheduling-Cron.md
+++ b/docs/pwsh/tutorial/12.scheduling/2.Scheduling-Cron.md
@@ -1,0 +1,42 @@
+---
+title: Scheduling with CRON
+parent: Scheduler
+nav_order: 2
+---
+
+# Scheduling with CRON
+
+Run jobs using 6-field CRON expressions with seconds precision.
+
+## Full source
+
+File: [`pwsh/tutorial/examples/12.2-Scheduling-Cron.ps1`][12.2-Scheduling-Cron.ps1]
+
+```powershell
+{% include examples/pwsh/12.2-Scheduling-Cron.ps1 %}
+```
+
+Notes:
+
+- Use `*/N` in the first field (seconds) for sub-minute cadence.
+- Combine PowerShell `ScriptBlock` and inline C# code as needed.
+- CRON format: six-field (seconds minutes hours day month day-of-week)
+
+[12.2-Scheduling-Cron.ps1]: /pwsh/tutorial/examples/12.2-Scheduling-Cron.ps1
+
+## Cmdlet references
+
+- [Register-KrSchedule][Register-KrSchedule]
+- [Get-KrScheduleReport][Get-KrScheduleReport]
+
+---
+
+### Next
+
+{: .fs-4 .fw-500}
+
+Continue to [Scheduling Report endpoint][Next]
+
+[Register-KrSchedule]: /pwsh/cmdlets/Register-KrSchedule
+[Get-KrScheduleReport]: /pwsh/cmdlets/Get-KrScheduleReport
+[Next]: ./3.Scheduling-Report

--- a/docs/pwsh/tutorial/12.scheduling/3.Scheduling-Report.md
+++ b/docs/pwsh/tutorial/12.scheduling/3.Scheduling-Report.md
@@ -1,0 +1,45 @@
+---
+title: Scheduling Report
+parent: Scheduler
+nav_order: 3
+---
+
+# Scheduling Report
+
+Expose an endpoint that returns the aggregated schedule report, optionally in a specific time zone.
+
+## Full source
+
+File: [`pwsh/tutorial/examples/12.3-Scheduling-Report.ps1`][12.3-Scheduling-Report.ps1]
+
+```powershell
+{% include examples/pwsh/12.3-Scheduling-Report.ps1 %}
+```
+
+Try it:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:5000/schedule/report | ConvertTo-Json -Depth 4
+Invoke-RestMethod 'http://127.0.0.1:5000/schedule/report?tz=Pacific Standard Time' | ConvertTo-Json -Depth 4
+```
+
+[12.3-Scheduling-Report.ps1]: /pwsh/tutorial/examples/12.3-Scheduling-Report.ps1
+
+## Cmdlet references
+
+- [Get-KrScheduleReport][Get-KrScheduleReport]
+- [Register-KrSchedule][Register-KrSchedule]
+- [Add-KrScheduling][Add-KrScheduling]
+
+---
+
+### Next
+
+{: .fs-4 .fw-500}
+
+Continue to [Server configuration][Next]
+
+[Get-KrScheduleReport]: /pwsh/cmdlets/Get-KrScheduleReport
+[Register-KrSchedule]: /pwsh/cmdlets/Register-KrSchedule
+[Add-KrScheduling]: /pwsh/cmdlets/Add-KrScheduling
+[Next]: ../13.server-configuration/

--- a/docs/pwsh/tutorial/12.scheduling/index.md
+++ b/docs/pwsh/tutorial/12.scheduling/index.md
@@ -4,177 +4,23 @@ parent: Tutorials
 nav_order: 12
 ---
 
-# Kestrun Scheduler
+# Scheduler Tutorials
 
-> 🚧 **Work in Progress**
->
-> This page is currently under development. Content will be expanded with guides, examples, and best practices soon.
-> Thank you for your patience while we build it out.
+Run background jobs on intervals or CRON (seconds precision) in PowerShell or C#. Enable once, then register jobs and query live status.
 
-## Overview
+## Chapters
 
-Kestrun’s built-in **SchedulerService** lets your server run background jobs on fixed intervals or CRON expressions, in either **C#** or **PowerShell**.
-Out-of-the-box you can:
+| # | Topic | Summary |
+|---|-------|---------|
+| 1 | [Scheduling Quickstart](./1.Scheduling-Quickstart) | Enable scheduler, register PS/C# heartbeats, expose visit counter and report |
+| 2 | [Scheduling with CRON](./2.Scheduling-Cron) | CRON-based jobs with seconds precision |
+| 3 | [Scheduling Report](./3.Scheduling-Report) | Report endpoint with optional timezone |
 
-- **Register jobs** — interval or 6-field cron (seconds precision).
-- **Run work in-process**:
+Planned:
 
-  - *C#*: any `Func<CancellationToken,Task>` delegate.
-  - *PowerShell*: inline `ScriptBlock` **or** a script file.
-- **Pause / resume / cancel** individual jobs at runtime.
-- **Query live status** (UTC or any time-zone) as a strongly-typed *report* or a plain `Hashtable`.
-- **Drive everything from PowerShell** via a small set of cmdlets.
+- Cron expressions and time zones
+- Pause/Resume/Cancel patterns
+- Script-file jobs with parameters and environment
+- Operational recipes (logging, retries, idempotency)
 
-| C# Type / PS Cmdlet    | Purpose                                                                                                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **`SchedulerService`** | Core service: register, suspend, resume, cancel, snapshot, report.                                                 |
-| `ScheduledTask`        | Immutable job record (name, trigger, timestamps, suspension flag).                                                 |
-| **PowerShell**         | `Register-KrSchedule`, `Suspend-KrSchedule`, `Resume-KrSchedule`, `Get-KrScheduleSnapshot`, `Get-KrScheduleReport` |
-
----
-
-## 1. Enabling the scheduler
-
-```csharp
-var host = new KestrunHost("MyApp");
-host.EnableScheduling();          // queues the feature
-host.ApplyQueuedFeatures();       // executed once before StartAsync
-```
-
-> `EnableScheduling()` creates one shared **Runspace pool** (for PS jobs)
-> and attaches a `SchedulerService` instance to `host.Scheduler`.
-
----
-
-## 2. Registering jobs (C#)
-
-### 2.1  Fixed interval
-
-```csharp
-host.Scheduler.Schedule(
-    name: "heartbeat",
-    interval: TimeSpan.FromSeconds(10),
-    job: ct =>
-    {
-        Log.Information("💓  {Now:O}", DateTimeOffset.UtcNow);
-        return Task.CompletedTask;
-    },
-    runImmediately: true);
-```
-
-### 2.2  CRON (seconds-precision)
-
-```csharp
-host.Scheduler.Schedule(
-    "cleanup",
-    "0 0 3 * * *",                      // every day 03:00
-    async ct => await CleanupAsync(ct));
-```
-
----
-
-## 3. Registering jobs (PowerShell)
-
-### 3.1  Inline `ScriptBlock` (interval)
-
-```powershell
-Register-KrSchedule -Name Cache -Interval '00:15:00' {
-    Write-KrInfo "⏰ Cache refresh at $(Get-Date -f o)"
-}
-```
-
-### 3.2  Script file (cron)
-
-```powershell
-Register-KrSchedule -Name Nightly `
-                    -Cron '0 0 3 * * *' `
-                    -ScriptPath 'Scripts/Cleanup.ps1' `
-                    -RunImmediately
-```
-
----
-
-## 4. Controlling jobs
-
-```powershell
-# Pause a job
-Suspend-KrSchedule -Name Nightly
-
-# Resume it later
-Resume-KrSchedule -Name Nightly
-
-# Delete it entirely
-$host.Scheduler.Cancel("Nightly")
-```
-
----
-
-## 5. Reporting & snapshot
-
-```powershell
-# Strongly-typed .NET report in UTC
-$report = Get-KrScheduleReport
-
-# Same, but Pacific time and as Hashtable
-Get-KrScheduleReport -TimeZoneId 'Pacific Standard Time' -AsHashtable
-
-# Quick snapshot (wildcards allowed)
-Get-KrScheduleSnapshot -Name 'ps-*' -AsHashtable |
-    ConvertTo-Json -Depth 3
-```
-
-Sample JSON report (UTC):
-
-```json
-{
-  "generatedAt": "2025-07-24T22:10:30Z",
-  "jobs": [
-    { "name":"heartbeat","lastRunAt":"2025-07-24T22:10:28Z","nextRunAt":"2025-07-24T22:10:38Z","isSuspended":false },
-    { "name":"ps-inline","lastRunAt":"2025-07-24T22:10:00Z","nextRunAt":"2025-07-24T22:11:00Z","isSuspended":false },
-    { "name":"nightly","lastRunAt":null,"nextRunAt":"2025-07-25T03:00:00Z","isSuspended":true }
-  ]
-}
-```
-
----
-
-## 6. API Reference (C#)
-
-| Method                                                                                       | What it does                                             |
-| -------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `Schedule(string name, TimeSpan interval, Func<…> job, bool runImmediately=false)`           | Register interval job (C# delegate).                     |
-| `Schedule(string name, string cron, Func<…> job, bool runImmediately=false)`                 | Register cron job (C# delegate).                         |
-| `Schedule(string name, TimeSpan interval, ScriptBlock script, …)`                            | Register interval PowerShell job (inline).               |
-| `Schedule(string name, string cron, FileInfo script, …)`                                     | Register cron job from *.ps1* file (async).              |
-| `Pause(string name) / Resume(string name)`                                                   | Toggle `IsSuspended`.                                    |
-| `Cancel(string name)`                                                                        | Remove job and cancel its loop.                          |
-| `GetSnapshot(TimeZoneInfo? tz = null, bool asHashtable = false, params string[] nameFilter)` | Lightweight listing (optionally wildcard-filtered & HT). |
-| `GetReport(TimeZoneInfo? tz = null)`                                                         | Full `ScheduleReport` (aggregated).                      |
-
-`JobInfo`: **Name**, **LastRunAt**, **NextRunAt**, **IsSuspended**.
-`ScheduleReport`: **GeneratedAt**, **Jobs\[]**.
-
----
-
-## 7. PowerShell Cmdlet Reference
-
-| Cmdlet                       | Purpose                                               | Notes                                     |
-| ---------------------------- | ----------------------------------------------------- | ----------------------------------------- |
-| **`Register-KrSchedule`**    | Create new schedule (interval/cron × block/file).     | Supports `-RunImmediately`.               |
-| **`Suspend-KrSchedule`**     | Pause a job.                                          | Wildcards not supported (use exact name). |
-| **`Resume-KrSchedule`**      | Resume a paused job.                                  | —                                         |
-| **`Get-KrScheduleSnapshot`** | Quick list, optional `-Name` filter & `-AsHashtable`. | UTC by default; `-TimeZoneId` switch.     |
-| **`Get-KrScheduleReport`**   | Aggregated report; `-AsHashtable` plus TZ.            | —                                         |
-
----
-
-## 8. Best practices
-
-| Tip                                                             | Why                                             |
-| --------------------------------------------------------------- | ----------------------------------------------- |
-| **Store timestamps internally in UTC**                          | Keeps math simple and reports consistent.       |
-| **Use `WaitAsync(token)`** when invoking PowerShell             | Allows job to cancel instantly on shutdown.     |
-| **Return `Task` from C# jobs**                                  | Prevents thread-pool starvation on async work.  |
-| **Keep runspace pools small** (`Options.MaxSchedulerRunspaces`) | Scheduler work is usually lightweight.          |
-| **Log failures inside `SafeRun`**                               | A failed job should never crash the server.     |
-| **Pause, don’t delete, for temporary outages**                  | `IsSuspended` keeps next execution predictable. |
+Return to the [Tutorial Index](../index).

--- a/docs/pwsh/tutorial/index.md
+++ b/docs/pwsh/tutorial/index.md
@@ -103,6 +103,9 @@ Stop the server with Ctrl+C in the terminal.
 | 51    | Health: Process Probe         | [Process Probe][ch-health-process]        | [Script][sc-health-4]           | External tool validation            |
 | 52    | Health: C# Inline Probe       | [C# Inline Probe][ch-health-csharp]       | [Script][sc-health-5]           | Inline .NET logic                   |
 | 53    | Health: Disk Probe            | [Disk Probe][ch-health-disk]              | [Script][sc-health-6]           | Disk space thresholds               |
+| 54    | Scheduler: Quickstart         | [Scheduling Quickstart][ch-sched-quick]   | [Script][sc-sched-quick]        | Enable scheduler, jobs, report      |
+| 55    | Scheduler: CRON               | [Scheduling with CRON][ch-sched-cron]     | [Script][sc-sched-cron]         | CRON expressions with seconds       |
+| 56    | Scheduler: Report             | [Scheduling Report][ch-sched-report]      | [Script][sc-sched-report]       | Report endpoint and timezone        |
 
 Static chapters and scripts are all linked directly above for quick navigation.
 
@@ -159,6 +162,9 @@ Static chapters and scripts are all linked directly above for quick navigation.
 [ch-health-process]: ./16.health/4.Health-Process-Probe
 [ch-health-csharp]: ./16.health/5.Health-CSharp-Probe
 [ch-health-disk]: ./16.health/6.Health-Disk-Probe
+[ch-sched-quick]: ./12.scheduling/1.Scheduling-Quickstart
+[ch-sched-cron]: ./12.scheduling/2.Scheduling-Cron
+[ch-sched-report]: ./12.scheduling/3.Scheduling-Report
 [sc-hello]: /pwsh/tutorial/examples/1.1-Hello-World.ps1
 [sc-content]: /pwsh/tutorial/examples/2.1-Multiple-Content-Types.ps1
 [sc-multilang]: /pwsh/tutorial/examples/2.2-Multi-Language-Routes.ps1
@@ -212,3 +218,6 @@ Static chapters and scripts are all linked directly above for quick navigation.
 [sc-health-4]: /pwsh/tutorial/examples/16.4-Health-Process-Probe.ps1
 [sc-health-5]: /pwsh/tutorial/examples/16.5-Health-CSharp-Probe.ps1
 [sc-health-6]: /pwsh/tutorial/examples/16.6-Health-Disk-Probe.ps1
+[sc-sched-quick]: /pwsh/tutorial/examples/12.1-Scheduling-Quickstart.ps1
+[sc-sched-cron]: /pwsh/tutorial/examples/12.2-Scheduling-Cron.ps1
+[sc-sched-report]: /pwsh/tutorial/examples/12.3-Scheduling-Report.ps1

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -15,6 +15,7 @@ Deeper, cross-cutting subjects (logging, deployment, performance, etc.).
 | [HTTP Caching](./caching) | Layered cache headers, middleware, validators |
 | [Health Monitoring](./health) | Health endpoints, probes, and operational guidance |
 | [JWT Tokens](./jwt) | Build, issue, validate, and renew JSON Web Tokens |
+| [Scheduling](./scheduling) | Background jobs via intervals and CRON (PS & C#) |
 
 ## Planned
 

--- a/docs/topics/scheduling.md
+++ b/docs/topics/scheduling.md
@@ -1,0 +1,133 @@
+---
+title: Scheduling
+parent: Guides
+nav_order: 50
+---
+
+# Kestrun Scheduling (Jobs & CRON)
+
+Kestrun’s built-in Scheduler lets your server run background jobs on fixed intervals or CRON expressions, in either C# or PowerShell.
+
+## Capabilities
+
+- Register jobs — interval or 6‑field CRON (seconds precision)
+- Run work in-process:
+  - C#: any `Func<CancellationToken, Task>` delegate, or inline code compiled via Roslyn
+  - PowerShell: inline `ScriptBlock` or a `.ps1` file
+- Pause / resume / cancel jobs at runtime
+- Query live status (UTC or any time-zone) as a strongly-typed report or PowerShell hashtable
+- Operate entirely from PowerShell cmdlets or directly via C# APIs
+
+## Enabling the scheduler (C#)
+
+```csharp
+var host = new KestrunHost("MyApp");
+host.EnableScheduling();          // queues the feature
+host.ApplyQueuedFeatures();       // executed once before StartAsync
+```
+
+Enabling creates a shared PowerShell Runspace pool for PS jobs and attaches a `SchedulerService` instance at `host.Scheduler`.
+
+## Registering jobs
+
+### PowerShell (inline)
+
+```powershell
+Register-KrSchedule -Name Cache -Interval '00:15:00' -ScriptBlock {
+    Write-KrInfo "⏰ Cache refresh at $(Get-Date -f o)"
+}
+```
+
+### PowerShell (script file via CRON)
+
+```powershell
+Register-KrSchedule -Name Nightly -Cron '0 0 3 * * *' -ScriptPath 'Scripts/Cleanup.ps1'
+```
+
+### C# (inline)
+
+```csharp
+host.Scheduler.Schedule(
+    name: "heartbeat",
+    interval: TimeSpan.FromSeconds(10),
+    job: ct => { Log.Information("💓 {Now:O}", DateTimeOffset.UtcNow); return Task.CompletedTask; },
+    runImmediately: true);
+```
+
+### C# (CRON)
+
+```csharp
+host.Scheduler.Schedule("cleanup", "0 0 3 * * *", async ct => await CleanupAsync(ct));
+```
+
+## Controlling jobs
+
+```powershell
+Suspend-KrSchedule -Name Nightly   # pause
+Resume-KrSchedule -Name Nightly    # resume
+```
+
+From C#, use `Pause(name)`, `Resume(name)`, or `Cancel(name)` on `SchedulerService`.
+
+## Reporting
+
+```powershell
+# Strongly-typed .NET report in UTC
+$report = Get-KrScheduleReport
+
+# Same, but Pacific time and as Hashtable
+Get-KrScheduleReport -TimeZoneId 'Pacific Standard Time' -AsHashtable
+
+# Quick snapshot (wildcards allowed)
+Get-KrScheduleSnapshot -Name 'ps-*' -AsHashtable | ConvertTo-Json -Depth 3
+```
+
+Sample (trimmed):
+
+```json
+{
+  "generatedAt": "2025-07-24T22:10:30Z",
+  "jobs": [
+    { "name":"heartbeat","lastRunAt":"2025-07-24T22:10:28Z","nextRunAt":"2025-07-24T22:10:38Z","isSuspended":false }
+  ]
+}
+```
+
+## API reference (C#)
+
+| Method | Purpose |
+|--------|---------|
+| `Schedule(string name, TimeSpan interval, Func<…> job, bool runImmediately=false)` | Register interval job (C# delegate) |
+| `Schedule(string name, string cron, Func<…> job, bool runImmediately=false)` | Register cron job (C# delegate) |
+| `Schedule(string name, TimeSpan interval, ScriptBlock script, …)` | Interval PowerShell job (inline) |
+| `Schedule(string name, string cron, FileInfo script, …)` | CRON job from .ps1 file |
+| `Pause(string name)` / `Resume(string name)` | Toggle `IsSuspended` |
+| `Cancel(string name)` | Remove job and stop its loop |
+| `GetSnapshot(TimeZoneInfo? tz = null, bool asHashtable = false, params string[] nameFilter)` | Lightweight listing |
+| `GetReport(TimeZoneInfo? tz = null)` | Full `ScheduleReport` |
+
+Types:
+
+- `JobInfo`: Name, LastRunAt, NextRunAt, IsSuspended
+- `ScheduleReport`: GeneratedAt, Jobs[]
+
+## PowerShell cmdlets
+
+- `Add-KrScheduling` — enable scheduler
+- `Register-KrSchedule` — create jobs (interval/cron × block/file/code)
+- `Suspend-KrSchedule` / `Resume-KrSchedule` — control execution
+- `Get-KrScheduleSnapshot` — quick list
+- `Get-KrScheduleReport` — aggregated report
+
+## Best practices
+
+- Store timestamps internally in UTC — consistent math & comparisons
+- Use `WaitAsync(token)` when invoking PowerShell — fast shutdowns
+- Return `Task` from C# jobs — avoid thread-pool starvation
+- Keep runspace pools small (`Options.MaxSchedulerRunspaces`) — jobs are usually light
+- Log failures inside job bodies — a failed job should never crash the server
+- Pause instead of delete for outages — preserves next run predictability
+
+## See also
+
+- Tutorial: [Scheduling Quickstart](/pwsh/tutorial/12.scheduling/1.Scheduling-Quickstart)

--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.1-Scheduling-Quickstart.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.1-Scheduling-Quickstart.Tests.ps1
@@ -1,0 +1,35 @@
+﻿param()
+Describe 'Tutorial 12.1 Scheduling Quickstart' -Tag 'Tutorial' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\PesterHelpers.ps1')
+        $script:instance = Start-ExampleScript -Name '12.1-Scheduling-Quickstart.ps1'
+    }
+    AfterAll {
+        if ($script:instance) { Stop-ExampleScript -Instance $script:instance }
+    }
+
+    It '/visit increments counter' {
+        $base = $script:instance.Url
+        $r1 = Invoke-WebRequest -Uri "$base/visit" -UseBasicParsing -TimeoutSec 8
+        $r1.StatusCode | Should -Be 200
+        $first = [int]([regex]::Match($r1.Content, '(\d+)').Groups[1].Value)
+
+        $r2 = Invoke-WebRequest -Uri "$base/visit" -UseBasicParsing -TimeoutSec 8
+        $r2.StatusCode | Should -Be 200
+        $second = [int]([regex]::Match($r2.Content, '(\d+)').Groups[1].Value)
+
+        $second | Should -BeGreaterThan $first
+    }
+
+    It '/schedule/report contains heartbeat jobs' {
+        $base = $script:instance.Url
+        $resp = Invoke-WebRequest -Uri "$base/schedule/report" -UseBasicParsing -TimeoutSec 12
+        $resp.StatusCode | Should -Be 200
+        $json = $resp.Content | ConvertFrom-Json
+
+        # Allow a short delay for first run if not immediate for both
+        $names = @($json.jobs | ForEach-Object { $_.name })
+        ($names -contains 'heartbeat-ps') | Should -BeTrue
+        ($names -contains 'heartbeat-cs') | Should -BeTrue
+    }
+}

--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.2-Scheduling-Cron.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.2-Scheduling-Cron.Tests.ps1
@@ -1,0 +1,18 @@
+﻿param()
+Describe 'Tutorial 12.2 Scheduling Cron' -Tag 'Tutorial' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\PesterHelpers.ps1')
+        $script:instance = Start-ExampleScript -Name '12.2-Scheduling-Cron.ps1'
+    }
+    AfterAll { if ($script:instance) { Stop-ExampleScript -Instance $script:instance } }
+
+    It '/schedule/report lists cron jobs' {
+        $base = $script:instance.Url
+        $resp = Invoke-WebRequest -Uri "$base/schedule/report" -UseBasicParsing -TimeoutSec 10
+        $resp.StatusCode | Should -Be 200
+        $json = $resp.Content | ConvertFrom-Json
+        $names = @($json.jobs | ForEach-Object { $_.name })
+        ($names -contains 'cron-ps') | Should -BeTrue
+        ($names -contains 'cron-cs') | Should -BeTrue
+    }
+}

--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.3-Scheduling-Report.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.3-Scheduling-Report.Tests.ps1
@@ -1,0 +1,37 @@
+﻿param()
+Describe 'Tutorial 12.3 Scheduling Report' -Tag 'Tutorial' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\PesterHelpers.ps1')
+        $script:instance = Start-ExampleScript -Name '12.3-Scheduling-Report.ps1'
+    }
+    AfterAll { if ($script:instance) { Stop-ExampleScript -Instance $script:instance } }
+
+    It '/schedule/report lists jobs' {
+        $base = $script:instance.Url
+        $resp = Invoke-WebRequest -Uri "$base/schedule/report" -UseBasicParsing -TimeoutSec 10
+        $resp.StatusCode | Should -Be 200
+        $json = $resp.Content | ConvertFrom-Json
+        $names = @($json.jobs | ForEach-Object { $_.name })
+        ($names -contains 'rep-ps') | Should -BeTrue
+        ($names -contains 'rep-cs') | Should -BeTrue
+    }
+
+    It '/schedule/report supports tz query' {
+        $base = $script:instance.Url
+        $candidates = @([System.TimeZoneInfo]::Local.Id, 'UTC')
+        $ok = $false
+        foreach ($tz in $candidates) {
+            try {
+                $enc = [System.Uri]::EscapeDataString($tz)
+                $resp = Invoke-WebRequest -Uri "$base/schedule/report?tz=$enc" -UseBasicParsing -TimeoutSec 10
+                if ($resp.StatusCode -eq 200) {
+                    $json = $resp.Content | ConvertFrom-Json
+                    $json | Should -Not -BeNullOrEmpty
+                    $json.generatedAt | Should -Not -BeNullOrEmpty
+                    $ok = $true; break
+                }
+            } catch { }
+        }
+        $ok | Should -BeTrue -Because 'At least one timezone id must be accepted by the server'
+    }
+}

--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.3-Scheduling-Report.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.3-Scheduling-Report.Tests.ps1
@@ -30,7 +30,9 @@ Describe 'Tutorial 12.3 Scheduling Report' -Tag 'Tutorial' {
                     $json.generatedAt | Should -Not -BeNullOrEmpty
                     $ok = $true; break
                 }
-            } catch { }
+            } catch { 
+                # Exception intentionally ignored to allow trying other timezone candidates.
+            }
         }
         $ok | Should -BeTrue -Because 'At least one timezone id must be accepted by the server'
     }


### PR DESCRIPTION
## Summary
This PR completes and publishes the Scheduler tutorial section and related topic for PowerShell. It adds runnable examples, documentation, and tests, and aligns the new pages to the Tutorials style (Cmdlet references + styled Next).

Fixes #109

## Changes
- Tutorials (PowerShell → Scheduler)
  - 12.1 Scheduling Quickstart — enable scheduler, register jobs (PS + C#), expose /visit and /schedule/report
  - 12.2 Scheduling with CRON — demonstrate six‑field CRON expressions (with seconds) and include a report endpoint
  - 12.3 Scheduling Report — robust report endpoint with optional tz query; validates timezone id and falls back to UTC
- Examples (docs includes)
  - docs/_includes/examples/pwsh/12.1-Scheduling-Quickstart.ps1
  - docs/_includes/examples/pwsh/12.2-Scheduling-Cron.ps1
  - docs/_includes/examples/pwsh/12.3-Scheduling-Report.ps1
- Topic
  - docs/topics/scheduling.md — overview, best practices, cmdlets, and links
- Index updates
  - docs/pwsh/tutorial/12.scheduling/index.md — section index linking the three chapters
  - docs/pwsh/tutorial/index.md — added Scheduler entries to the overview table
  - docs/topics/index.md — linked the new Scheduling topic
- Tests (Pester)
  - tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.1-Scheduling-Quickstart.Tests.ps1
  - tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.2-Scheduling-Cron.Tests.ps1
  - tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-12.3-Scheduling-Report.Tests.ps1

## Documentation compliance
- Converted pages to use "## Cmdlet references" (cmdlet link-refs) and styled "### Next" blocks
- Followed Just‑the‑Docs conventions and navigation
- Avoided here‑strings in inline C# (compatibility with test harness param injection)
- Hardened timezone handling in report example to prevent 500s on invalid tz ids

## How to try
- Run any example directly from docs includes (or copy to a temp folder):
  - PowerShell: `pwsh docs/_includes/examples/pwsh/12.1-Scheduling-Quickstart.ps1`
  - Then GET the endpoints: `/visit` and `/schedule/report`
- Run tests:
  - PowerShell (Pester): `Invoke-Build Test-Pester` or `Invoke-Build Test` (runs xUnit + Pester)

## Risks / Breaking changes
- Docs and tests only; no public API or runtime behavior changes in the core library.

## Checklist (project)
- [x] Commit messages follow Conventional Commits (docs scope)
- [x] Docs are Just‑the‑Docs compliant and placed correctly (Tutorials/Topics)
- [x] Added tests for new tutorial samples (Pester)
- [x] Linked to issue with Fixes #109
- [ ] Build passes locally (no C# changes; can be verified on CI and with `Invoke-Build Build`)
- [ ] Tests pass locally (verified during development; re‑check on CI with `Invoke-Build Test`)

## Notes
- Branch naming: current branch is `doc-109-scheduler-documentation-and-samples`. If required, we can re-open from a slash‑style branch name (e.g., `docs/109-scheduler-documentation-and-samples`).