### PR TITLE
Use Server.Logger instead of Server.HostLogger in logging

### DIFF
--- a/src/PowerShell/Kestrun/Public/Server/Set-KrServerLimit.ps1
+++ b/src/PowerShell/Kestrun/Public/Server/Set-KrServerLimit.ps1
@@ -112,47 +112,47 @@ function Set-KrServerLimit {
             throw 'Server is not initialized.Please ensure the server is configured before setting limits.'
         }
         if ($MaxRequestBodySize -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRequestBodySize to {MaxRequestBodySize} bytes" -Values $MaxRequestBodySize
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRequestBodySize to {MaxRequestBodySize} bytes" -Values $MaxRequestBodySize
             $options.ServerLimits.MaxRequestBodySize = $MaxRequestBodySize
         }
         if ($MaxConcurrentConnections -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxConcurrentConnections to {MaxConcurrentConnections}" -Values $MaxConcurrentConnections
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxConcurrentConnections to {MaxConcurrentConnections}" -Values $MaxConcurrentConnections
             $options.ServerLimits.MaxConcurrentConnections = $MaxConcurrentConnections
         }
         if ($MaxRequestHeaderCount -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRequestHeaderCount to {MaxRequestHeaderCount}" -Values $MaxRequestHeaderCount
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRequestHeaderCount to {MaxRequestHeaderCount}" -Values $MaxRequestHeaderCount
             $options.ServerLimits.MaxRequestHeaderCount = $MaxRequestHeaderCount
         }
         if ($KeepAliveTimeoutSeconds -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting KeepAliveTimeout to {KeepAliveTimeoutSeconds} seconds" -Values $KeepAliveTimeoutSeconds
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting KeepAliveTimeout to {KeepAliveTimeoutSeconds} seconds" -Values $KeepAliveTimeoutSeconds
             $options.ServerLimits.KeepAliveTimeout = [TimeSpan]::FromSeconds($KeepAliveTimeoutSeconds)
         }
         if ($MaxRequestBufferSize -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRequestBufferSize to {MaxRequestBufferSize} bytes" -Values $MaxRequestBufferSize
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRequestBufferSize to {MaxRequestBufferSize} bytes" -Values $MaxRequestBufferSize
             $options.ServerLimits.MaxRequestBufferSize = $MaxRequestBufferSize
         }
         if ($MaxRequestHeadersTotalSize -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRequestHeadersTotalSize to {MaxRequestHeadersTotalSize} bytes" -Values $MaxRequestHeadersTotalSize
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRequestHeadersTotalSize to {MaxRequestHeadersTotalSize} bytes" -Values $MaxRequestHeadersTotalSize
             $options.ServerLimits.MaxRequestHeadersTotalSize = $MaxRequestHeadersTotalSize
         }
         if ($MaxRequestLineSize -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRequestLineSize to {MaxRequestLineSize} bytes" -Values $MaxRequestLineSize
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRequestLineSize to {MaxRequestLineSize} bytes" -Values $MaxRequestLineSize
             $options.ServerLimits.MaxRequestLineSize = $MaxRequestLineSize
         }
         if ($MaxResponseBufferSize -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxResponseBufferSize to {MaxResponseBufferSize} bytes" -Values $MaxResponseBufferSize
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxResponseBufferSize to {MaxResponseBufferSize} bytes" -Values $MaxResponseBufferSize
             $options.ServerLimits.MaxResponseBufferSize = $MaxResponseBufferSize
         }
         if ($null -ne $MinRequestBodyDataRate) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MinRequestBodyDataRate to {MinRequestBodyDataRate} bytes/second" -Values $MinRequestBodyDataRate
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MinRequestBodyDataRate to {MinRequestBodyDataRate} bytes/second" -Values $MinRequestBodyDataRate
             $options.ServerLimits.MinRequestBodyDataRate = $MinRequestBodyDataRate
         }
         if ($null -ne $MinResponseDataRate) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MinResponseDataRate to {MinResponseDataRate} bytes/second" -Values $MinResponseDataRate
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MinResponseDataRate to {MinResponseDataRate} bytes/second" -Values $MinResponseDataRate
             $options.ServerLimits.MinResponseDataRate = $MinResponseDataRate
         }
         if ($null -ne $RequestHeadersTimeout) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting RequestHeadersTimeout to {RequestHeadersTimeout} seconds" -Values $RequestHeadersTimeout
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting RequestHeadersTimeout to {RequestHeadersTimeout} seconds" -Values $RequestHeadersTimeout
             $options.ServerLimits.RequestHeadersTimeout = [TimeSpan]::FromSeconds($RequestHeadersTimeoutSeconds)
         }
 

--- a/src/PowerShell/Kestrun/Public/Server/Set-KrServerNamedPipeOptions.ps1
+++ b/src/PowerShell/Kestrun/Public/Server/Set-KrServerNamedPipeOptions.ps1
@@ -69,23 +69,23 @@ function Set-KrServerNamedPipeOptions {
         if ($PSCmdlet.ParameterSetName -eq 'Items') {
             $Options = [Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions]::new()
             if ($null -ne $ListenerQueueCount) {
-                Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting NamedPipeOptions.ListenerQueueCount to {ListenerQueueCount}" -Values $ListenerQueueCount
+                Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting NamedPipeOptions.ListenerQueueCount to {ListenerQueueCount}" -Values $ListenerQueueCount
                 $options.ListenerQueueCount = $ListenerQueueCount
             }
             if ($null -ne $MaxReadBufferSize) {
-                Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting NamedPipeOptions.MaxReadBufferSize to {MaxReadBufferSize}" -Values $MaxReadBufferSize
+                Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting NamedPipeOptions.MaxReadBufferSize to {MaxReadBufferSize}" -Values $MaxReadBufferSize
                 $options.MaxReadBufferSize = $MaxReadBufferSize
             }
             if ($CurrentUserOnly.IsPresent) {
-                Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting NamedPipeOptions.CurrentUserOnly to {CurrentUserOnly}" -Values $CurrentUserOnly
+                Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting NamedPipeOptions.CurrentUserOnly to {CurrentUserOnly}" -Values $CurrentUserOnly
                 $Options.CurrentUserOnly = $true
             }
             if ($null -ne $MaxWriteBufferSize) {
-                Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting NamedPipeOptions.MaxWriteBufferSize to {MaxWriteBufferSize}" -Values $MaxWriteBufferSize
+                Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting NamedPipeOptions.MaxWriteBufferSize to {MaxWriteBufferSize}" -Values $MaxWriteBufferSize
                 $Options.MaxWriteBufferSize = $MaxWriteBufferSize
             }
             if ($null -ne $PipeSecurity) {
-                Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting NamedPipeOptions.PipeSecurity to {PipeSecurity}" -Values $PipeSecurity
+                Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting NamedPipeOptions.PipeSecurity to {PipeSecurity}" -Values $PipeSecurity
                 $Options.PipeSecurity = $PipeSecurity
             }
         }

--- a/src/PowerShell/Kestrun/Public/Server/Set-KrServerOptions.ps1
+++ b/src/PowerShell/Kestrun/Public/Server/Set-KrServerOptions.ps1
@@ -84,36 +84,36 @@ function Set-KrServerOptions {
         }
 
         if ($AllowSynchronousIO.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.AllowSynchronousIO to {AllowSynchronousIO}" -Values $AllowSynchronousIO.IsPresent
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.AllowSynchronousIO to {AllowSynchronousIO}" -Values $AllowSynchronousIO.IsPresent
             $options.ServerOptions.AllowSynchronousIO = $AllowSynchronousIO.IsPresent
         }
         if ($DisableResponseHeaderCompression.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.AllowResponseHeaderCompression to {AllowResponseHeaderCompression}" `
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.AllowResponseHeaderCompression to {AllowResponseHeaderCompression}" `
                 -Values $false
             $options.ServerOptions.AllowResponseHeaderCompression = $false
         }
         if ($DenyServerHeader.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.AddServerHeader to {AddServerHeader}" -Values $false
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.AddServerHeader to {AddServerHeader}" -Values $false
             $options.ServerOptions.AddServerHeader = $false
         }
         if ($AllowAlternateSchemes.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.AllowAlternateSchemes to {AllowAlternateSchemes}" -Values $true
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.AllowAlternateSchemes to {AllowAlternateSchemes}" -Values $true
             $options.ServerOptions.AllowAlternateSchemes = $true
         }
         if ($AllowHostHeaderOverride.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.AllowHostHeaderOverride to {AllowHostHeaderOverride}" -Values $true
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.AllowHostHeaderOverride to {AllowHostHeaderOverride}" -Values $true
             $options.ServerOptions.AllowHostHeaderOverride = $true
         }
         if ($DisableStringReuse.IsPresent) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting ServerOptions.DisableStringReuse to {DisableStringReuse}" -Values $true
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting ServerOptions.DisableStringReuse to {DisableStringReuse}" -Values $true
             $options.ServerOptions.DisableStringReuse = $true
         }
         if ($MaxRunspaces -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MaxRunspaces to {MaxRunspaces}" -Values $MaxRunspaces
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MaxRunspaces to {MaxRunspaces}" -Values $MaxRunspaces
             $options.MaxRunspaces = $MaxRunspaces
         }
         if ($MinRunspaces -gt 0) {
-            Write-KrLog -Logger $Server.HostLogger -Level Verbose -Message "Setting MinRunspaces to {MinRunspaces}" -Values $MinRunspaces
+            Write-KrLog -Logger $Server.Logger -Level Verbose -Message "Setting MinRunspaces to {MinRunspaces}" -Values $MinRunspaces
             $options.MinRunspaces = $MinRunspaces
         }
 


### PR DESCRIPTION
This pull request updates logging throughout the server configuration PowerShell scripts to use the unified logger property. Previously, log messages used `HostLogger`, but now all logging uses the main `Logger` property on the `Server` object. This change ensures consistency in logging and may help centralize log management.

Logging consistency improvements:

* Updated all calls to `Write-KrLog` in `Set-KrServerLimit.ps1` to use `$Server.Logger` instead of `$Server.HostLogger` when logging server limit changes.
* Changed all logging in `Set-KrServerNamedPipeOptions.ps1` to use `$Server.Logger` for named pipe option changes.
* Modified all logging in `Set-KrServerOptions.ps1` to use `$Server.Logger` for server option changes, including synchronous IO, response header compression, server header, alternate schemes, host header override, string reuse, and runspace limits.Replaces all instances of $Server.HostLogger with $Server.Logger in Set-KrServerLimit.ps1, Set-KrServerNamedPipeOptions.ps1, and Set-KrServerOptions.ps1 for logging operations. This change standardizes logger usage across server configuration scripts.

# Pull Request

Thank you for contributing to **Kestrun** 💫
Please use this template to help us review your PR efficiently.

---

## 📋 Summary

Describe the purpose of this PR in a few sentences.
Example: *Add `Add-KrRouteGroup` cmdlet to simplify route grouping in PowerShell.*

---

## 🔗 Related Issues

Link any issues this PR addresses:
Closes #123
Related to #456

---

## 🛠️ Changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Maintenance
- [ ] Other (please describe)

---

## ✅ Checklist

- [x] Code follows project style (C# + PowerShell guidelines)
- [x] Tests added/updated for new/changed functionality  
- [x] Documentation updated (README, docs.kestrun.dev, or inline XML/Comment-based help)
- [x] CI/CD passes locally (`Invoke-Build Test`)
- [x] Commit messages are clear and conventional

---

## 💡 Additional Notes

Anything else reviewers should know?
Screenshots, benchmarks, design notes, etc.
