### PR TITLE
Add and extend tests for Kestrun context and scripting

### DIFF
--- a/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunContextBroadcastTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunContextBroadcastTests.cs
@@ -1,0 +1,133 @@
+using Kestrun.Hosting;
+using Kestrun.Models;
+using Kestrun.SignalR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace KestrunTests.Models;
+
+[Trait("Category", "Models")]
+public sealed class KestrunContextBroadcastTests
+{
+    private static KestrunContext NewContext(IServiceProvider? services)
+    {
+        var host = new KestrunHost("Tests", AppContext.BaseDirectory);
+        var http = new DefaultHttpContext();
+        http.Request.Method = "GET";
+        http.Request.Path = "/";
+
+        // KestrunContext requires a RouteEndpoint to resolve route metadata
+        http.SetEndpoint(new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("/"),
+            order: 0,
+            metadata: EndpointMetadataCollection.Empty,
+            displayName: "TestEndpoint"));
+
+        http.RequestServices = services!;
+
+        return new KestrunContext(host, http);
+    }
+
+    [Fact]
+    public async Task BroadcastLogAsync_NoServiceProvider_ReturnsFalse()
+    {
+        var ctx = NewContext(services: null);
+        var ok = await ctx.BroadcastLogAsync("Information", "hello");
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task BroadcastLogAsync_NoBroadcasterRegistered_ReturnsFalse()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var ctx = NewContext(sp);
+
+        var ok = await ctx.BroadcastLogAsync("Information", "hello");
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task BroadcastLogAsync_BroadcasterRegistered_CallsServiceAndReturnsTrue()
+    {
+        var mock = new Mock<IRealtimeBroadcaster>(MockBehavior.Strict);
+        mock.Setup(b => b.BroadcastLogAsync("Information", "hello", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sp = new ServiceCollection()
+            .AddSingleton(mock.Object)
+            .BuildServiceProvider();
+
+        var ctx = NewContext(sp);
+
+        var ok = await ctx.BroadcastLogAsync("Information", "hello");
+        Assert.True(ok);
+
+        mock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task BroadcastLogAsync_BroadcasterThrows_ReturnsFalse()
+    {
+        var mock = new Mock<IRealtimeBroadcaster>(MockBehavior.Strict);
+        mock.Setup(b => b.BroadcastLogAsync("Information", "boom", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("fail"));
+
+        var sp = new ServiceCollection()
+            .AddSingleton(mock.Object)
+            .BuildServiceProvider();
+
+        var ctx = NewContext(sp);
+
+        var ok = await ctx.BroadcastLogAsync("Information", "boom");
+        Assert.False(ok);
+
+        mock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task BroadcastEventAsync_BroadcasterRegistered_CallsServiceAndReturnsTrue()
+    {
+        var payload = new { a = 1 };
+
+        var mock = new Mock<IRealtimeBroadcaster>(MockBehavior.Strict);
+        mock.Setup(b => b.BroadcastEventAsync("evt", payload, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sp = new ServiceCollection()
+            .AddSingleton(mock.Object)
+            .BuildServiceProvider();
+
+        var ctx = NewContext(sp);
+
+        var ok = await ctx.BroadcastEventAsync("evt", payload);
+        Assert.True(ok);
+
+        mock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task BroadcastToGroupAsync_BroadcasterRegistered_CallsServiceAndReturnsTrue()
+    {
+        var payload = new { a = 1 };
+
+        var mock = new Mock<IRealtimeBroadcaster>(MockBehavior.Strict);
+        mock.Setup(b => b.BroadcastToGroupAsync("group", "method", payload, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sp = new ServiceCollection()
+            .AddSingleton(mock.Object)
+            .BuildServiceProvider();
+
+        var ctx = NewContext(sp);
+
+        var ok = await ctx.BroadcastToGroupAsync("group", "method", payload);
+        Assert.True(ok);
+
+        mock.VerifyAll();
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunContextTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunContextTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Kestrun.Models;
 using Kestrun.Hosting;
+using Kestrun.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
@@ -15,6 +16,12 @@ public class KestrunContextTests
     {
         var host = new KestrunHost("Tests", AppContext.BaseDirectory);
 
+        return NewContext(host, http);
+    }
+
+    private static KestrunContext NewContext(KestrunHost host, DefaultHttpContext http)
+    {
+
         if (string.IsNullOrWhiteSpace(http.Request.Method))
         {
             http.Request.Method = "GET";
@@ -24,6 +31,49 @@ public class KestrunContextTests
         http.SetEndpoint(new RouteEndpoint(_ => Task.CompletedTask, RoutePatternFactory.Parse(http.Request.Path.HasValue ? http.Request.Path.Value : "/"), 0, EndpointMetadataCollection.Empty, "TestEndpoint"));
 
         return new KestrunContext(host, http);
+    }
+
+    [Fact]
+    [Trait("Category", "Hosting")]
+    public void Constructor_WhenNoEndpoint_FallsBackToRootPattern()
+    {
+        var host = new KestrunHost("Tests", AppContext.BaseDirectory);
+        var http = new DefaultHttpContext();
+        http.Request.Method = "POST";
+        http.Request.Path = "/api/anything";
+
+        // Intentionally do NOT set an endpoint.
+        var ctx = new KestrunContext(host, http);
+
+        Assert.Equal("/", ctx.MapRouteOptions.Pattern);
+        Assert.Contains(HttpVerb.Post, ctx.MapRouteOptions.HttpVerbs);
+    }
+
+    [Fact]
+    [Trait("Category", "Hosting")]
+    public void Constructor_WhenRouteRegistered_UsesRegisteredMapRouteOptions()
+    {
+        var host = new KestrunHost("Tests", AppContext.BaseDirectory);
+
+        var registered = new Kestrun.Hosting.Options.MapRouteOptions
+        {
+            Pattern = "/api/registered",
+            HttpVerbs = [HttpVerb.Get]
+        };
+        host.RegisteredRoutes[("/api/registered", HttpVerb.Get)] = registered;
+
+        var http = new DefaultHttpContext();
+        http.Request.Method = "GET";
+        http.Request.Path = "/api/registered";
+        http.SetEndpoint(new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("/api/registered"),
+            order: 0,
+            metadata: EndpointMetadataCollection.Empty,
+            displayName: "TestEndpoint"));
+
+        var ctx = NewContext(host, http);
+        Assert.Same(registered, ctx.MapRouteOptions);
     }
 
     [Fact]

--- a/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunResponseApplyToAdditionalTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Models/KestrunResponseApplyToAdditionalTests.cs
@@ -1,0 +1,144 @@
+using Kestrun.Callback;
+using Kestrun.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text;
+using Xunit;
+
+namespace KestrunTests.Models;
+
+public partial class KestrunResponseTests
+{
+    [Fact]
+    [Trait("Category", "Models")]
+    public async Task ApplyTo_WhenRedirectUrlSet_UsesRedirectAndSkipsBodyWrite()
+    {
+        var ctx = TestRequestFactory.CreateContext();
+        var res = ctx.Response;
+        res.WriteRedirectResponse("https://example.invalid/target");
+
+        var http = new DefaultHttpContext();
+        using var ms = new MemoryStream();
+        http.Response.Body = ms;
+
+        await res.ApplyTo(http.Response);
+
+        Assert.Equal(StatusCodes.Status302Found, http.Response.StatusCode);
+        Assert.True(http.Response.Headers.TryGetValue("Location", out var location));
+        Assert.Equal("https://example.invalid/target", location.ToString());
+
+        Assert.Equal(0, ms.Length);
+    }
+
+    [Fact]
+    [Trait("Category", "Models")]
+    public async Task ApplyTo_AppendsSetCookieHeaders_WhenCookiesPresent()
+    {
+        var ctx = TestRequestFactory.CreateContext();
+        var res = ctx.Response;
+
+        res.Cookies = new List<string>
+        {
+            "a=b; Path=/; HttpOnly",
+            "c=d; Path=/"
+        };
+
+        await res.WriteTextResponseAsync("ok", StatusCodes.Status200OK, "text/plain");
+
+        var http = new DefaultHttpContext();
+        using var ms = new MemoryStream();
+        http.Response.Body = ms;
+
+        await res.ApplyTo(http.Response);
+
+        Assert.True(http.Response.Headers.TryGetValue("Set-Cookie", out var cookies));
+        Assert.True(cookies.Count > 0);
+        var all = cookies.ToArray();
+        Assert.Contains(all, c => c is not null && c.Contains("a=b", StringComparison.Ordinal));
+        Assert.Contains(all, c => c is not null && c.Contains("c=d", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Category", "Models")]
+    public async Task ApplyTo_SetsCacheControlHeader_WhenConfigured()
+    {
+        var ctx = TestRequestFactory.CreateContext();
+        var res = ctx.Response;
+
+        res.CacheControl = new CacheControlHeaderValue
+        {
+            NoStore = true,
+            NoCache = true
+        };
+
+        await res.WriteTextResponseAsync("ok", StatusCodes.Status200OK, "text/plain");
+
+        var http = new DefaultHttpContext();
+        using var ms = new MemoryStream();
+        http.Response.Body = ms;
+
+        await res.ApplyTo(http.Response);
+
+        Assert.True(http.Response.Headers.TryGetValue(HeaderNames.CacheControl, out var cc));
+        Assert.Contains("no-store", cc.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Category", "Models")]
+    public async Task ApplyTo_StatusOnly_ClearsContentTypeAndLength()
+    {
+        var ctx = TestRequestFactory.CreateContext();
+        var res = ctx.Response;
+
+        res.WriteStatusOnly(StatusCodes.Status204NoContent);
+
+        var http = new DefaultHttpContext();
+        http.Response.ContentType = "text/plain";
+        http.Response.ContentLength = 123;
+
+        await res.ApplyTo(http.Response);
+
+        Assert.Equal(StatusCodes.Status204NoContent, http.Response.StatusCode);
+        Assert.Null(http.Response.ContentType);
+        Assert.Null(http.Response.ContentLength);
+    }
+
+    [Fact]
+    [Trait("Category", "Models")]
+    public async Task ApplyTo_WithCallbacksButNoDispatcher_DoesNotThrow_AndStillWritesBody()
+    {
+        var ctx = TestRequestFactory.CreateContext(configureContext: http =>
+        {
+            http.RequestServices = new ServiceCollection().BuildServiceProvider();
+        });
+
+        var res = ctx.Response;
+
+        var callbackPlan = new CallbackPlan(
+            CallbackId: "cb",
+            UrlTemplate: "https://example.invalid/callback",
+            Method: HttpMethod.Post,
+            OperationId: "op",
+            PathParams: Array.Empty<CallbackParamPlan>(),
+            Body: null);
+
+        res.CallbackPlan.Add(new CallBackExecutionPlan(
+            CallbackId: "cb",
+            Plan: callbackPlan,
+            BodyParameterName: null,
+            Parameters: new Dictionary<string, object?>()));
+
+        await res.WriteTextResponseAsync("hello", StatusCodes.Status200OK, "text/plain");
+
+        var http2 = new DefaultHttpContext();
+        using var ms = new MemoryStream();
+        http2.Response.Body = ms;
+
+        await res.ApplyTo(http2.Response);
+
+        ms.Position = 0;
+        using var reader = new StreamReader(ms, Encoding.UTF8);
+        Assert.Equal("hello", reader.ReadToEnd());
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/Scripting/LanguageRuntimePipelineTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Scripting/LanguageRuntimePipelineTests.cs
@@ -1,0 +1,101 @@
+using Kestrun.Scripting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace KestrunTests.Scripting;
+
+[Trait("Category", "Scripting")]
+public sealed class LanguageRuntimePipelineTests
+{
+    [Fact]
+    public async Task UseLanguageRuntime_AppliesBranchOnlyWhenMetadataMatches()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+
+        app.UseLanguageRuntime(ScriptLanguage.PowerShell, branch =>
+        {
+            branch.Use(async (ctx, next) =>
+            {
+                ctx.Response.Headers["X-Lang"] = "PowerShell";
+                await next(ctx);
+            });
+        });
+
+        app.MapGet("/ps", () => Results.Text("ok"))
+            .WithLanguage(ScriptLanguage.PowerShell);
+
+        app.MapGet("/cs", () => Results.Text("ok"))
+            .WithLanguage(ScriptLanguage.CSharp);
+
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var ps = await client.GetAsync("/ps");
+        Assert.True(ps.Headers.Contains("X-Lang"));
+
+        var cs = await client.GetAsync("/cs");
+        Assert.False(cs.Headers.Contains("X-Lang"));
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task WithLanguage_AddsScriptLanguageAttributeMetadata()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+
+        app.MapGet("/ps", () => Results.Text("ok"))
+            .WithLanguage(ScriptLanguage.PowerShell);
+
+        await app.StartAsync();
+
+        var endpoints = ((IEndpointRouteBuilder)app).DataSources.SelectMany(ds => ds.Endpoints).OfType<RouteEndpoint>().ToList();
+        var endpoint = endpoints.FirstOrDefault(e => string.Equals(e.RoutePattern.RawText, "/ps", StringComparison.Ordinal));
+
+        Assert.NotNull(endpoint);
+
+        var attr = endpoint!.Metadata.GetMetadata<ScriptLanguageAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal(ScriptLanguage.PowerShell, attr!.Language);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task UseLanguageRuntime_WhenNoEndpointMetadata_DoesNotApplyBranch()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+
+        app.UseLanguageRuntime(ScriptLanguage.PowerShell, branch =>
+        {
+            branch.Use(async (ctx, next) =>
+            {
+                ctx.Response.Headers["X-Lang"] = "PowerShell";
+                await next(ctx);
+            });
+        });
+
+        // No WithLanguage metadata
+        app.MapGet("/plain", () => Results.Text("ok"));
+
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var resp = await client.GetAsync("/plain");
+        Assert.False(resp.Headers.Contains("X-Lang"));
+
+        await app.StopAsync();
+    }
+}


### PR DESCRIPTION
# Summary
Added new test files for KestrunContext broadcasting, response application, and scripting language runtime pipeline. Extended KestrunContextTests to cover route registration and endpoint fallback logic. These changes improve coverage and validation of context, response, and scripting behaviors.

# Pull Request
 

---

## 🔗 Related Issues

Link any issues this PR addresses:
Closes #123
Related to #456

---

## 🛠️ Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Maintenance
- [x] Other (please describe)

---

## ✅ Checklist

- [ ] Code follows project style (C# + PowerShell guidelines)
- [x] Tests added/updated for new/changed functionality  
- [ ] Documentation updated (README, docs.kestrun.dev, or inline XML/Comment-based help)
- [ ] CI/CD passes locally (`Invoke-Build Test`)
- [ ] Commit messages are clear and conventional

---

## 💡 Additional Notes

Anything else reviewers should know?
Screenshots, benchmarks, design notes, etc.
