### PR TITLE
Add unit tests for SSE broadcaster and formatter

### DIFF
--- a/tests/CSharp.Tests/Kestrun.Tests/Sse/InMemorySseBroadcasterTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Sse/InMemorySseBroadcasterTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Channels;
+using Serilog;
+using Xunit;
+using Xunit.Sdk;
+
+namespace KestrunTests.Sse;
+
+public class InMemorySseBroadcasterTests
+{
+    [Trait("Category", "Sse")]
+    [Fact]
+    public void Subscribe_IncrementsConnectedCount_AndReturnsUniqueClientIds()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+
+        var sub1 = broadcaster.Subscribe(CancellationToken.None);
+        var sub2 = broadcaster.Subscribe(CancellationToken.None);
+
+        Assert.Equal(2, broadcaster.ConnectedCount);
+        Assert.False(string.IsNullOrWhiteSpace(sub1.ClientId));
+        Assert.False(string.IsNullOrWhiteSpace(sub2.ClientId));
+        Assert.NotEqual(sub1.ClientId, sub2.ClientId);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public async Task BroadcastAsync_WritesFormattedPayloadToAllSubscribers()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+        var sub1 = broadcaster.Subscribe(CancellationToken.None);
+        var sub2 = broadcaster.Subscribe(CancellationToken.None);
+
+        await broadcaster.BroadcastAsync(eventName: "message", data: "hello", id: "42", retryMs: 1000);
+
+        var expected = Kestrun.Sse.SseEventFormatter.Format("message", "hello", "42", 1000);
+        var p1 = await ReadWithTimeoutAsync(sub1.Reader, TimeSpan.FromSeconds(2));
+        var p2 = await ReadWithTimeoutAsync(sub2.Reader, TimeSpan.FromSeconds(2));
+
+        Assert.Equal(expected, p1);
+        Assert.Equal(expected, p2);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public async Task BroadcastAsync_WhenNoClients_DoesNotThrow()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+
+        await broadcaster.BroadcastAsync(eventName: "message", data: "hello");
+
+        Assert.Equal(0, broadcaster.ConnectedCount);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public async Task Subscribe_WhenCanceled_RemovesClientAndCompletesReader()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+        using var cts = new CancellationTokenSource();
+
+        var sub = broadcaster.Subscribe(cts.Token);
+        Assert.Equal(1, broadcaster.ConnectedCount);
+
+        cts.Cancel();
+
+        var removed = await WaitForAsync(() => broadcaster.ConnectedCount == 0, TimeSpan.FromSeconds(2));
+        Assert.True(removed);
+
+        await AssertCompletesAsync(sub.Reader, TimeSpan.FromSeconds(2));
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public async Task BroadcastAsync_WhenCanceledToken_DoesNotWrite()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+        var sub = broadcaster.Subscribe(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await broadcaster.BroadcastAsync(eventName: "x", data: "y", cancellationToken: cts.Token);
+
+        Assert.False(sub.Reader.TryRead(out _));
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public async Task BroadcastAsync_WhenClientChannelCompleted_RemovesClient()
+    {
+        var broadcaster = new Kestrun.Sse.InMemorySseBroadcaster(CreateNullLogger());
+        var sub = broadcaster.Subscribe(CancellationToken.None);
+        Assert.Equal(1, broadcaster.ConnectedCount);
+
+        // Simulate a broken client channel without removing it from the broadcaster.
+        // This forces Writer.TryWrite(payload) to fail so the broadcaster removes the client.
+        var clients = GetClientDictionary(broadcaster);
+        Assert.True(clients.TryGetValue(sub.ClientId, out var channel));
+        _ = channel.Writer.TryComplete();
+
+        await broadcaster.BroadcastAsync(eventName: "x", data: "y");
+
+        var removed = await WaitForAsync(() => broadcaster.ConnectedCount == 0, TimeSpan.FromSeconds(2));
+        Assert.True(removed);
+    }
+
+    private static ILogger CreateNullLogger() =>
+        new LoggerConfiguration().MinimumLevel.Verbose().CreateLogger();
+
+    private static ConcurrentDictionary<string, Channel<string>> GetClientDictionary(Kestrun.Sse.InMemorySseBroadcaster broadcaster)
+    {
+        var field = typeof(Kestrun.Sse.InMemorySseBroadcaster)
+            .GetField("_clients", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+
+        var value = field.GetValue(broadcaster);
+        Assert.NotNull(value);
+
+        return (ConcurrentDictionary<string, Channel<string>>)value;
+    }
+
+    private static async Task<string> ReadWithTimeoutAsync(ChannelReader<string> reader, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            return await reader.ReadAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new XunitException($"Timed out waiting for SSE payload after {timeout}.");
+        }
+    }
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return condition();
+    }
+
+    private static async Task AssertCompletesAsync(ChannelReader<string> reader, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(reader.Completion, Task.Delay(timeout)) == reader.Completion;
+        Assert.True(completed);
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/Sse/SseEventFormatterTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Sse/SseEventFormatterTests.cs
@@ -1,0 +1,63 @@
+using Xunit;
+
+namespace KestrunTests.Sse;
+
+public class SseEventFormatterTests
+{
+    [Trait("Category", "Sse")]
+    [Fact]
+    public void Format_IncludesRetryIdEventAndData_AndEndsWithBlankLine()
+    {
+        var payload = Kestrun.Sse.SseEventFormatter.Format(
+            eventName: "tick",
+            data: "hello",
+            id: "1",
+            retryMs: 2000);
+
+        Assert.Equal(
+            "retry: 2000\n" +
+            "id: 1\n" +
+            "event: tick\n" +
+            "data: hello\n" +
+            "\n",
+            payload);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public void Format_OmitsWhitespaceEventAndId()
+    {
+        var payload = Kestrun.Sse.SseEventFormatter.Format(
+            eventName: " ",
+            data: "one\ntwo\r\nthree",
+            id: "\t",
+            retryMs: null);
+
+        Assert.Equal(
+            "data: one\n" +
+            "data: two\n" +
+            "data: three\n" +
+            "\n",
+            payload);
+        Assert.DoesNotContain("event:", payload);
+        Assert.DoesNotContain("id:", payload);
+        Assert.DoesNotContain("retry:", payload);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public void Format_WhenDataIsEmpty_ReturnsOnlyTerminator()
+    {
+        var payload = Kestrun.Sse.SseEventFormatter.Format(eventName: null, data: string.Empty);
+
+        Assert.Equal("\n", payload);
+    }
+
+    [Trait("Category", "Sse")]
+    [Fact]
+    public void FormatComment_UsesCommentWireFormat()
+    {
+        var payload = Kestrun.Sse.SseEventFormatter.FormatComment("keep-alive");
+        Assert.Equal(": keep-alive\n\n", payload);
+    }
+}


### PR DESCRIPTION
Introduces tests for InMemorySseBroadcaster and SseEventFormatter covering subscription, broadcasting, cancellation, and event formatting logic to ensure correct SSE behavior.

# Pull Request

Thank you for contributing to **Kestrun** 💫
Please use this template to help us review your PR efficiently.

---

## 📋 Summary

Describe the purpose of this PR in a few sentences.
Example: *Add `Add-KrRouteGroup` cmdlet to simplify route grouping in PowerShell.*

---

## 🔗 Related Issues

Link any issues this PR addresses:
Closes #123
Related to #456

---

## 🛠️ Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Maintenance
- [ ] Other (please describe)

---

## ✅ Checklist

- [ ] Code follows project style (C# + PowerShell guidelines)
- [ ] Tests added/updated for new/changed functionality  
- [ ] Documentation updated (README, docs.kestrun.dev, or inline XML/Comment-based help)
- [ ] CI/CD passes locally (`Invoke-Build Test`)
- [ ] Commit messages are clear and conventional

---

## 💡 Additional Notes

Anything else reviewers should know?
Screenshots, benchmarks, design notes, etc.
