### PR TITLE
Demote non-public Kestrun helper types to internal

### DIFF
--- a/src/CSharp/Kestrun/Callback/CallbackRuntimeContextFactory.cs
+++ b/src/CSharp/Kestrun/Callback/CallbackRuntimeContextFactory.cs
@@ -6,7 +6,7 @@ namespace Kestrun.Callback;
 /// <summary>
 /// Factory for creating <see cref="CallbackRuntimeContext"/> instances from HTTP context.
 /// </summary>
-public static partial class CallbackRuntimeContextFactory
+internal static partial class CallbackRuntimeContextFactory
 {
     // Matches {id} and {id:int} etc; ignores {$request.body#/...} because of / and #
     private static readonly Regex TemplateParamRegex =
@@ -97,4 +97,3 @@ public static partial class CallbackRuntimeContextFactory
     [GeneratedRegex(@"\{(?<name>[^{}:/\?]+)(?:[:][^{}]+)?\}", RegexOptions.Compiled)]
     private static partial Regex TemplateParameterRegex();
 }
-

--- a/src/CSharp/Kestrun/Callback/CallbackWorker.cs
+++ b/src/CSharp/Kestrun/Callback/CallbackWorker.cs
@@ -14,7 +14,7 @@ namespace Kestrun.Callback;
 /// <param name="retry"> The callback retry policy.</param>
 /// <param name="log"> The logger.</param>
 /// <param name="store"> The optional callback store.</param>
-public sealed class CallbackWorker(
+internal sealed class CallbackWorker(
     InMemoryCallbackQueue queue,
     ICallbackSender sender,
     ICallbackRetryPolicy retry,

--- a/src/CSharp/Kestrun/Callback/DefaultCallbackRetryPolicy.cs
+++ b/src/CSharp/Kestrun/Callback/DefaultCallbackRetryPolicy.cs
@@ -5,7 +5,7 @@ namespace Kestrun.Callback;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DefaultCallbackRetryPolicy"/> class.
 /// </remarks>
-public sealed class DefaultCallbackRetryPolicy : ICallbackRetryPolicy
+internal sealed class DefaultCallbackRetryPolicy : ICallbackRetryPolicy
 {
     private readonly int _maxAttempts;
     private readonly TimeSpan _baseDelay;

--- a/src/CSharp/Kestrun/Callback/DefaultCallbackUrlResolver.cs
+++ b/src/CSharp/Kestrun/Callback/DefaultCallbackUrlResolver.cs
@@ -6,7 +6,7 @@ namespace Kestrun.Callback;
 /// Default implementation of <see cref="ICallbackUrlResolver"/> that resolves callback URLs
 /// using JSON Pointer expressions and variable tokens.
 /// </summary>
-public sealed partial class DefaultCallbackUrlResolver : ICallbackUrlResolver
+internal sealed partial class DefaultCallbackUrlResolver : ICallbackUrlResolver
 {
     private static readonly Regex RuntimeExpr = GeneratedRuntimeRegex();
 

--- a/src/CSharp/Kestrun/Callback/HttpCallbackSender.cs
+++ b/src/CSharp/Kestrun/Callback/HttpCallbackSender.cs
@@ -7,7 +7,7 @@ namespace Kestrun.Callback;
 /// </remarks>
 /// <param name="http"> The HTTP client to use for sending requests.</param>
 /// <param name="signer"> The optional callback signer for signing requests.</param>
-public sealed class HttpCallbackSender(HttpClient http, ICallbackSigner? signer = null) : ICallbackSender
+internal sealed class HttpCallbackSender(HttpClient http, ICallbackSigner? signer = null) : ICallbackSender
 {
     private readonly HttpClient _http = http;
     private readonly ICallbackSigner? _signer = signer; // optional

--- a/src/CSharp/Kestrun/Callback/InMemoryCallbackDispatchWorker.cs
+++ b/src/CSharp/Kestrun/Callback/InMemoryCallbackDispatchWorker.cs
@@ -14,7 +14,7 @@ namespace Kestrun.Callback;
 /// <param name="queue">The in-memory callback queue.</param>
 /// <param name="httpClientFactory">The HTTP client factory.</param>
 /// <param name="log">The logger instance.</param>
-public sealed class InMemoryCallbackDispatchWorker(
+internal sealed class InMemoryCallbackDispatchWorker(
     InMemoryCallbackQueue queue,
     IHttpClientFactory httpClientFactory,
     Serilog.ILogger log) : BackgroundService

--- a/src/CSharp/Kestrun/Callback/InMemoryCallbackDispatcher.cs
+++ b/src/CSharp/Kestrun/Callback/InMemoryCallbackDispatcher.cs
@@ -7,7 +7,7 @@ namespace Kestrun.Callback;
 /// Initializes a new instance of the <see cref="InMemoryCallbackDispatcher"/> class.
 /// </remarks>
 /// <param name="queue">The in-memory callback queue to use for dispatching callbacks.</param>
-public sealed class InMemoryCallbackDispatcher(InMemoryCallbackQueue queue) : ICallbackDispatcher
+internal sealed class InMemoryCallbackDispatcher(InMemoryCallbackQueue queue) : ICallbackDispatcher
 {
     private readonly InMemoryCallbackQueue _queue = queue;
 

--- a/src/CSharp/Kestrun/Callback/InMemoryCallbackQueue.cs
+++ b/src/CSharp/Kestrun/Callback/InMemoryCallbackQueue.cs
@@ -5,7 +5,7 @@ namespace Kestrun.Callback;
 /// <summary>
 /// In-memory queue for callback requests.
 /// </summary>
-public sealed class InMemoryCallbackQueue
+internal sealed class InMemoryCallbackQueue
 {
     /// <summary>
     /// The channel for callback requests.

--- a/src/CSharp/Kestrun/Callback/JsonCallbackBodySerializer.cs
+++ b/src/CSharp/Kestrun/Callback/JsonCallbackBodySerializer.cs
@@ -5,7 +5,7 @@ namespace Kestrun.Callback;
 /// <summary>
 /// JSON implementation of <see cref="ICallbackBodySerializer"/>.
 /// </summary>
-public sealed class JsonCallbackBodySerializer : ICallbackBodySerializer
+internal sealed class JsonCallbackBodySerializer : ICallbackBodySerializer
 {
     /// <summary>
     /// Serializes the callback body based on the provided plan and context.

--- a/src/CSharp/Kestrun/Forms/KrPartDecompression.cs
+++ b/src/CSharp/Kestrun/Forms/KrPartDecompression.cs
@@ -5,7 +5,7 @@ namespace Kestrun.Forms;
 /// <summary>
 /// Provides per-part decompression helpers.
 /// </summary>
-public static class KrPartDecompression
+internal static class KrPartDecompression
 {
     /// <summary>
     /// Wraps a stream in a decompression stream based on the content encoding.
@@ -40,7 +40,7 @@ public static class KrPartDecompression
 /// </remarks>
 /// <param name="inner">The inner stream.</param>
 /// <param name="maxBytes">The maximum number of bytes allowed.</param>
-public sealed class LimitedReadStream(Stream inner, long maxBytes) : Stream
+internal sealed class LimitedReadStream(Stream inner, long maxBytes) : Stream
 {
     private readonly Stream _inner = inner;
     private readonly long _maxBytes = maxBytes;

--- a/src/CSharp/Kestrun/Localization/StringTableParser.cs
+++ b/src/CSharp/Kestrun/Localization/StringTableParser.cs
@@ -7,7 +7,7 @@ namespace Kestrun.Localization;
 /// <summary>
 /// Parses PowerShell-style string table files containing key=value pairs.
 /// </summary>
-public static class StringTableParser
+internal static class StringTableParser
 {
     /// <summary>
     /// Parses a string table file and returns a dictionary of key/value pairs.

--- a/src/CSharp/Kestrun/Logging/Enrichers/ErrorRecordEnricher.cs
+++ b/src/CSharp/Kestrun/Logging/Enrichers/ErrorRecordEnricher.cs
@@ -7,7 +7,7 @@ namespace Kestrun.Logging.Enrichers;
 /// <summary>
 /// Enriches Serilog log events with error record and invocation info from WrapperException.
 /// </summary>
-public class ErrorRecordEnricher : ILogEventEnricher
+internal class ErrorRecordEnricher : ILogEventEnricher
 {
     /// <summary>
     /// The property name used for the error record in log events.


### PR DESCRIPTION
## Summary
- demote internal callback helper implementations from `public` to `internal`
- demote non-public forms, localization, and logging helper types to `internal`
- keep the change set conservative to avoid breaking PowerShell-facing APIs

## Validation
- targeted C# tests passed earlier for the affected areas
- `Invoke-Build Build` passed earlier
- full Pester validation was attempted, but local reruns hit environment-specific process/file-lock issues around the repo module payload while I was validating on this machine