### PR TITLE
fix(help): normalize generated cmdlet front matter (Fixes #380)

### DIFF
--- a/Utility/Build-Help.ps1
+++ b/Utility/Build-Help.ps1
@@ -29,7 +29,7 @@ if (Test-Path -Path "$OutDir/about_.md") {
 }
 # Import PlatyPS module
 if (-not (Get-Module -ListAvailable -Name Microsoft.PowerShell.PlatyPS)) {
-    Write-Host "📦 Installing Microsoft.PowerShell.PlatyPS..."
+    Write-Host '📦 Installing Microsoft.PowerShell.PlatyPS...'
     Install-Module Microsoft.PowerShell.PlatyPS -Force -Scope CurrentUser
 }
 Import-Module Microsoft.PowerShell.PlatyPS
@@ -115,17 +115,29 @@ foreach ($f in $files) {
     }
 
     $raw = ($lines -join "`n")
+    $contentBody = [regex]::Replace(
+        $raw,
+        '\A---\r?\n.*?\r?\n---\r?\n?',
+        '',
+        [System.Text.RegularExpressions.RegexOptions]::Singleline)
 
-    if ($raw -notmatch '^\s*---\s*$') {
-        @"
+    if ([string]::IsNullOrWhiteSpace($contentBody)) {
+        $contentBody = $raw
+    }
+
+    $contentBody = $contentBody.TrimStart("`r", "`n")
+
+    @"
 ---
 layout: default
 parent: PowerShell Cmdlets
 nav_order: $i
 render_with_liquid: false
-$($raw.Substring(5))
+title: $($f.BaseName)
+
+$contentBody
 "@ | Set-Content $f.FullName -NoNewline
-    }
+
     $i++
 }
 

--- a/Utility/Build-Help.ps1
+++ b/Utility/Build-Help.ps1
@@ -117,16 +117,15 @@ foreach ($f in $files) {
     $raw = ($lines -join "`n")
     $contentBody = [regex]::Replace(
         $raw,
-        '\A---\r?\n.*?\r?\n---\r?\n?',
+        '^\uFEFF?(?:[ \t]*\r?\n)*[ \t]*---\r?\n.*?\r?\n---\r?\n?',
         '',
         [System.Text.RegularExpressions.RegexOptions]::Singleline)
 
     if ([string]::IsNullOrWhiteSpace($contentBody)) {
-        $contentBody = $raw
+        $contentBody = ''
+    } else {
+        $contentBody = $contentBody.TrimStart("`r", "`n")
     }
-
-    $contentBody = $contentBody.TrimStart("`r", "`n")
-
     @"
 ---
 layout: default


### PR DESCRIPTION
# Pull Request

## 📋 Summary
Normalize generated cmdlet markdown front matter in `Utility/Build-Help.ps1`.

The script now strips any existing YAML front matter from generated cmdlet pages, trims leading blank lines from the remaining body, and always rewrites a clean Just-the-Docs header with an explicit `title` derived from the file name.

## 🔗 Related Issues
Closes #380

## 🛠️ Changes
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / Maintenance
- [ ] Other (please describe)

## ✅ Checklist
- [x] Code follows project style (C# + PowerShell guidelines)
- [ ] Tests added/updated for new/changed functionality  
- [ ] Documentation updated (README, docs.kestrun.dev, or inline XML/Comment-based help)
- [ ] CI/CD passes locally (`Invoke-Build Test`)
- [x] Commit messages are clear and conventional

## 💡 Additional Notes
Validation run in a fresh PowerShell process:

```powershell
./Utility/Build-Help.ps1 -OutDir './artifacts/build-help-validation' -NotEmitXmlHelp
```

That run completed successfully and regenerated markdown help under `./artifacts/build-help-validation`.

This PR is intentionally scoped to `Utility/Build-Help.ps1` only.