### PR TITLE
Add Kestrun MCP server and inspection tools

### DIFF
--- a/.codex/skills/kestrun-mcp/SKILL.md
+++ b/.codex/skills/kestrun-mcp/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: kestrun-mcp
+description: Build and maintain a Model Context Protocol (MCP) server for Kestrun. Use this skill for tasks involving MCP tool design, route inspection, OpenAPI exposure, runtime inspection, request validation, safe endpoint invocation, tests, and docs.
+---
+
+# Kestrun MCP skill
+
+Use this skill when the task is about adding or improving MCP support in the Kestrun repository.
+
+## Goal
+
+Create and maintain a minimal, safe, extensible MCP server for Kestrun that exposes structured tools over existing Kestrun abstractions.
+
+## Repository context
+
+Kestrun is a hybrid PowerShell + ASP.NET Core framework built on Kestrel.
+
+Important architectural expectations:
+- Reuse existing Kestrun route registration, route metadata, runtime, and OpenAPI generation.
+- Do not duplicate logic that already exists in the framework.
+- Prefer thin adapters over new parallel models.
+- Keep changes focused and idiomatic to the repo.
+
+## First-choice MCP capabilities
+
+For initial implementations, prioritize these tools:
+
+1. `kestrun.list_routes`
+   - Return all registered routes.
+   - Include pattern, verbs, tags, summaries, request content types, response content types, and handler identity when available.
+
+2. `kestrun.get_route`
+   - Return detailed metadata for one route.
+   - Include request/response schema details when available from OpenAPI metadata.
+
+3. `kestrun.get_openapi`
+   - Return generated OpenAPI output in structured JSON form.
+   - Support selecting the target OpenAPI version if Kestrun supports multiple versions.
+
+4. `kestrun.inspect_runtime`
+   - Return safe runtime details such as uptime, start time, listeners, route counts, and environment information that is safe to expose.
+
+5. `kestrun.validate_request`
+   - Predict whether a proposed request matches route requirements.
+   - Explain likely 400, 404, 406, or 415 outcomes.
+
+6. `kestrun.invoke_route`
+   - Only implement when explicitly requested or already enabled by configuration.
+   - Must invoke through the normal Kestrun pipeline.
+   - Must respect content-type validation, Accept negotiation, and existing framework behavior.
+
+## Safety rules
+
+- Default to local developer scenarios.
+- Do not expose secrets, private keys, tokens, certificates, or hidden configuration values.
+- Redact sensitive headers by default.
+- Do not add destructive admin actions in v1.
+- Gate request invocation behind explicit configuration if there is any risk of misuse.
+- Do not create a broad remote execution surface.
+
+## Design rules
+
+- Prefer a dedicated project or module such as `src/Kestrun.Mcp` if that fits the repo structure.
+- Keep transport/protocol handling separate from Kestrun business logic.
+- Build small internal adapters or services if needed.
+- Favor JSON-serializable outputs with stable shapes.
+- Return structured errors for route-not-found, unsupported media type, unacceptable Accept header, binding failures, and internal exceptions.
+
+## Implementation workflow
+
+When asked to work on MCP support:
+
+1. Inspect the repository for the best insertion point.
+2. Identify the internal source of truth for:
+   - routes
+   - route options
+   - OpenAPI metadata
+   - runtime state
+3. Propose the smallest viable implementation plan.
+4. Implement incrementally.
+5. Add or update tests.
+6. Add or update docs.
+7. Summarize what changed and how it was verified.
+
+## Testing expectations
+
+Always add tests for changed behavior.
+
+Prioritize:
+- route discovery
+- route detail lookup
+- OpenAPI retrieval
+- missing route handling
+- validation outcomes
+- Accept mismatch behavior
+- invalid content-type behavior
+- request invocation if implemented
+
+Prefer deterministic integration tests with small example Kestrun apps or scripts.
+
+## Documentation expectations
+
+When adding or changing MCP functionality:
+- document the available MCP tools
+- explain how to run the MCP server
+- explain how to connect a client
+- document the safety model
+- include at least one simple example
+
+## Kestrun-specific guidance
+
+- Respect existing behavior for:
+  - allowed request content types
+  - default response content type
+  - Accept negotiation
+  - multipart and form handling
+  - framework-generated 400/404/406/415 responses
+- Prefer using existing metadata objects over parsing emitted text.
+- Extend internal route models carefully if required fields are missing.
+
+## Avoid
+
+- broad refactors unrelated to MCP
+- duplicated OpenAPI logic
+- speculative abstractions with no immediate use
+- placeholder code without tests and docs
+
+## Definition of done
+
+A task is complete when:
+- the implementation fits the current Kestrun architecture
+- tests cover the new behavior
+- docs are updated
+- the final summary explains what was added, what was verified, and any remaining follow-up work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This repository uses GitHub Copilot custom instructions as the main source of coding conventions.
+
+## Always load these instructions
+
+- Read `.github/copilot-instructions.md` if present.
+- Read the relevant files in `.github/instructions/` based on the task.
+
+## Task routing
+
+- C# changes: `.github/instructions/csharp.instructions.md`
+- PowerShell module changes: `.github/instructions/powershell-module.instructions.md`
+- Pester tests: `.github/instructions/pester.instructions.md`
+- OpenAPI work: `.github/instructions/openapi.instructions.md`
+- Docs work: `.github/instructions/docs.instructions.md`
+- Razor/UI work: `.github/instructions/razor.instructions.md`
+- Tutorial/sample work: `.github/instructions/tutorial-sample.instructions.md`
+- GitHub workflow and collaboration tasks: `.github/instructions/github-collaboration.instructions.md`
+
+## Working rules
+
+- Reuse existing abstractions instead of duplicating logic.
+- Keep changes focused.
+- Add or update tests for behavioral changes.
+- Update docs for user-visible changes.
+- Prefer the smallest viable design that matches the current architecture.
+
+## Validation
+
+- Run relevant build, lint, and test steps for the area you changed.
+- Summarize what changed, how it was verified, and any follow-up work.

--- a/Kestrun.build.ps1
+++ b/Kestrun.build.ps1
@@ -166,10 +166,12 @@ $KestrunMcpProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Ke
 $KestrunToolProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.Tool/Kestrun.Tool.csproj'
 $KestrunServiceHostProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.ServiceHost/Kestrun.ServiceHost.csproj'
 $KestrunCoreTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.Tests/Kestrun.Tests.csproj'
+$KestrunMcpTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.Mcp.Tests/Kestrun.Mcp.Tests.csproj'
 $KestrunToolTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.Tool.Tests/Kestrun.Tool.Tests.csproj'
 $KestrunServiceHostTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.ServiceHost.Tests/Kestrun.ServiceHost.Tests.csproj'
 $KestrunRunnerTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.Runner.Tests/Kestrun.Runner.Tests.csproj'
 $KestrunDedicatedNet10TestProjects = @(
+    $KestrunMcpTestProjectPath,
     $KestrunToolTestProjectPath,
     $KestrunServiceHostTestProjectPath,
     $KestrunRunnerTestProjectPath
@@ -586,7 +588,7 @@ Add-BuildTask 'Test-xUnit' {
             }
         }
     } else {
-        Write-Host 'ℹ️ Skipping dedicated Tool/ServiceHost/Runner tests because net10.0 is not in -Frameworks.' -ForegroundColor Yellow
+        Write-Host 'ℹ️ Skipping dedicated MCP/Tool/ServiceHost/Runner tests because net10.0 is not in -Frameworks.' -ForegroundColor Yellow
     }
 
     $initialFailedSelectors = @(
@@ -963,6 +965,7 @@ Add-BuildTask 'Coverage' {
     Write-Host '📊 Creating coverage report...'
     & "$utilityPath/Build-Coverage.ps1" -TestProjects @(
         $KestrunCoreTestProjectPath,
+        $KestrunMcpTestProjectPath,
         $KestrunToolTestProjectPath,
         $KestrunServiceHostTestProjectPath,
         $KestrunRunnerTestProjectPath
@@ -978,6 +981,7 @@ Add-BuildTask 'Report-Coverage' {
     Write-Host '🌐 Creating coverage report webpage...'
     & "$utilityPath/Build-Coverage.ps1" -ReportGenerator -TestProjects @(
         $KestrunCoreTestProjectPath,
+        $KestrunMcpTestProjectPath,
         $KestrunToolTestProjectPath,
         $KestrunServiceHostTestProjectPath,
         $KestrunRunnerTestProjectPath

--- a/Kestrun.build.ps1
+++ b/Kestrun.build.ps1
@@ -162,6 +162,7 @@ if ($isDebug) {
 $SolutionPath = Join-Path -Path $PSScriptRoot -ChildPath 'Kestrun.sln'
 $KestrunProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun/Kestrun.csproj'
 $KestrunAnnotationsProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.Annotations/Kestrun.Annotations.csproj'
+$KestrunMcpProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj'
 $KestrunToolProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.Tool/Kestrun.Tool.csproj'
 $KestrunServiceHostProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'src/CSharp/Kestrun.ServiceHost/Kestrun.ServiceHost.csproj'
 $KestrunCoreTestProjectPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests/CSharp.Tests/Kestrun.Tests/Kestrun.Tests.csproj'
@@ -252,6 +253,7 @@ Add-BuildTask Help {
     Write-Host '- Remove-Module: Removes the Kestrun module.'
     Write-Host '- Update-Module: Updates the Kestrun module.'
     # Build tasks
+    Write-Host '- Build-KestrunMcp: Builds the Kestrun.Mcp stdio MCP host project for net10.0 using the current -Configuration value.'
     Write-Host '- Build-KestrunTool: Publishes dedicated ServiceHost runtimes and stages PowerShell Modules payloads in src/CSharp/Kestrun.Tool/kestrun-service using the current -Configuration value.'
     Write-Host '- Build-Help: Generates PowerShell help documentation.'
     Write-Host '- Build-TutorialIndex: Regenerates docs/pwsh/tutorial/index.md.'
@@ -420,6 +422,16 @@ Add-BuildTask 'Build-KestrunTool' {
         -PublishRoot $kestrunToolPublishRoot `
         -CacheRoot $KestrunToolPowerShellCacheRoot `
         -ServiceHostRuntimesDirectory $kestrunToolServiceHostRuntimesDirectory
+}
+
+Add-BuildTask 'Build-KestrunMcp' {
+    Write-Host "🔧 Building Kestrun.Mcp using configuration: $Configuration"
+
+    dotnet build "$KestrunMcpProjectPath" -c $Configuration -f net10.0 -v:$DotNetVerbosity `
+        -p:Version=$Version -p:InformationalVersion="$($VersionDetails.InformationalVersion)"
+    if ($LASTEXITCODE -ne 0) {
+        throw 'dotnet build failed for Kestrun.Mcp.'
+    }
 }
 
 Add-BuildTask 'Pack-KestrunTool' 'Set-PackageConfiguration', 'Build-KestrunTool', {

--- a/Kestrun.sln
+++ b/Kestrun.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.Runner.Tests", "tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.Mcp", "src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj", "{7C9D0892-41C2-4A29-947F-0763C0B0F44F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.Mcp.Tests", "tests\CSharp.Tests\Kestrun.Mcp.Tests\Kestrun.Mcp.Tests.csproj", "{1C3CC3D7-40B4-4596-A0BE-E07B92354815}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -277,6 +279,18 @@ Global
 		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x64.Build.0 = Release|Any CPU
 		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x86.Build.0 = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Debug|x86.Build.0 = Debug|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|x64.Build.0 = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -301,6 +315,7 @@ Global
 		{4716981B-98E5-4098-B824-FE39730CE359} = {DA54316F-963F-7369-678C-9CA40476469A}
 		{D3C419DE-7986-4D58-A020-5821A917CFC2} = {DA54316F-963F-7369-678C-9CA40476469A}
 		{7C9D0892-41C2-4A29-947F-0763C0B0F44F} = {EE222B14-4095-D8D2-8B9B-4218DD5B4CA2}
+		{1C3CC3D7-40B4-4596-A0BE-E07B92354815} = {DA54316F-963F-7369-678C-9CA40476469A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5A8405A-3496-4792-BBE8-72C4C659DF34}

--- a/Kestrun.sln
+++ b/Kestrun.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.ServiceHost.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.Runner.Tests", "tests\CSharp.Tests\Kestrun.Runner.Tests\Kestrun.Runner.Tests.csproj", "{D3C419DE-7986-4D58-A020-5821A917CFC2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kestrun.Mcp", "src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj", "{7C9D0892-41C2-4A29-947F-0763C0B0F44F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -263,6 +265,18 @@ Global
 		{D3C419DE-7986-4D58-A020-5821A917CFC2}.Release|x64.Build.0 = Release|Any CPU
 		{D3C419DE-7986-4D58-A020-5821A917CFC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3C419DE-7986-4D58-A020-5821A917CFC2}.Release|x86.Build.0 = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x64.Build.0 = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -286,6 +300,7 @@ Global
 		{B1614A2D-6EBB-407C-ADC7-A69646A5FD1C} = {DA54316F-963F-7369-678C-9CA40476469A}
 		{4716981B-98E5-4098-B824-FE39730CE359} = {DA54316F-963F-7369-678C-9CA40476469A}
 		{D3C419DE-7986-4D58-A020-5821A917CFC2} = {DA54316F-963F-7369-678C-9CA40476469A}
+		{7C9D0892-41C2-4A29-947F-0763C0B0F44F} = {EE222B14-4095-D8D2-8B9B-4218DD5B4CA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5A8405A-3496-4792-BBE8-72C4C659DF34}

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Use the dedicated build task:
 Invoke-Build Build-KestrunMcp
 ```
 
+Typical local workflow:
+
+1. Point `Kestrun.Mcp` at a PowerShell script that starts a Kestrun host.
+2. Call `kestrun.inspect_runtime` to confirm the listener is up.
+3. Call `kestrun.list_routes` or `kestrun.get_route` to inspect the live route table.
+4. Call `kestrun.get_openapi` to retrieve the generated OpenAPI document as JSON.
+5. Call `kestrun.validate_request` to explain likely `404`, `406`, or `415` outcomes before sending a request.
+6. Call `kestrun.invoke_route` only for routes explicitly allowlisted with `--allow-invoke`.
+
+Practical examples shipped in this branch:
+
+- `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1` for route discovery, runtime inspection, and safe `GET /hello` invocation
+- `docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1` for route schema inspection, OpenAPI retrieval, request validation, and safe `POST /items/{id}` invocation
+
 Then configure your MCP client to launch `Kestrun.Mcp` with a target script and optional `--allow-invoke` route globs.
 See the full guide: [docs/guides/mcp.md](docs/guides/mcp.md).
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ You can find guides, API references, and usage examples to help you get started 
 - **📘 OpenAPI + interactive docs**
   Generate OpenAPI (v3.0 / v3.1 / v3.2) and serve docs UIs (Swagger UI / ReDoc / Scalar / RapiDoc / Elements).
 
+- **🤖 MCP server**
+  Expose route discovery, OpenAPI inspection, runtime inspection, request validation, and gated safe route invocation to MCP-compatible clients with `Kestrun.Mcp`.
+
 - **🔁 Realtime**
   Server-Sent Events (SSE) and SignalR support.
 
@@ -147,6 +150,21 @@ Download PowerShell from the official
   cd Kestrun
   ```
 
+  Build the core project and sync the PowerShell module:
+
+  ```powershell
+  Invoke-Build Restore
+  Invoke-Build Build
+  ```
+
+  Build the MCP host explicitly when you want the stdio server:
+
+  ```powershell
+  Invoke-Build Build-KestrunMcp
+  ```
+
+  For MCP setup and client configuration, see [docs/guides/mcp.md](docs/guides/mcp.md).
+
 - **🛠️ CI/CD ready**
   - Build- and run-time configurable
   - Works in containerized / headless environments
@@ -165,6 +183,27 @@ Download PowerShell from the official
   - **Cron-based scheduling**: Full cron expression support via Cronos
   - **Multi-language job support**: Schedule PowerShell, C#, and VB.NET scripts as background jobs
   - **Job management**: Start, stop, and monitor scheduled tasks with detailed logging
+
+## MCP Server
+
+Kestrun includes a standalone stdio MCP host project at `src/CSharp/Kestrun.Mcp/`.
+It lets MCP-compatible clients connect to a local Kestrun script and use tools for:
+
+- route discovery
+- route metadata lookup
+- generated OpenAPI retrieval
+- runtime inspection
+- request validation
+- gated safe route invocation
+
+Use the dedicated build task:
+
+```powershell
+Invoke-Build Build-KestrunMcp
+```
+
+Then configure your MCP client to launch `Kestrun.Mcp` with a target script and optional `--allow-invoke` route globs.
+See the full guide: [docs/guides/mcp.md](docs/guides/mcp.md).
 
 ## Deployment & Extensibility
 
@@ -242,6 +281,7 @@ See [docs/](docs/) for structure.
 ## Project Structure
 
 - `src/CSharp/` — C# core libraries and web server
+  - `Kestrun.Mcp` — stdio MCP host for route, OpenAPI, runtime, and safe invocation tools
   - `Kestrun/Authentication` — authentication handlers and schemes
   - `Kestrun/Certificates` — certificate management utilities
   - `Kestrun/Hosting` — host configuration and extensions

--- a/docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1
+++ b/docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1
@@ -1,0 +1,17 @@
+param(
+    [int]$Port = $env:PORT ?? 5000
+)
+
+New-KrServer -Name 'MCP Hello'
+
+Add-KrEndpoint -Port $Port
+
+Enable-KrConfiguration
+
+Add-KrMapRoute -Pattern '/hello' -Verbs Get -ScriptBlock {
+    Write-KrJsonResponse @{
+        message = 'hello from Kestrun'
+    }
+}
+
+Start-KrServer

--- a/docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1
+++ b/docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1
@@ -1,0 +1,40 @@
+using namespace Kestrun
+using namespace Kestrun.OpenApi
+
+param(
+    [int]$Port = $env:PORT ?? 5001
+)
+
+New-KrServer -Name 'MCP OpenAPI'
+
+Add-KrEndpoint -Port $Port
+
+Add-KrOpenApiInfo -Title 'Items API' `
+    -Version '1.0.0' `
+    -Description 'A minimal OpenAPI-aware route for MCP inspection.'
+
+Enable-KrConfiguration
+
+<#
+.SYNOPSIS
+    Create an item.
+#>
+function NewItemRoute {
+    [OpenApiPath(Pattern = '/items/{id}', HttpVerb = 'post', OperationId = 'createItem', Tags = @('items'))]
+    param(
+        [OpenApiParameter(In = [OaParameterLocation]::Path, Required = $true)]
+        [string] $id,
+
+        [OpenApiRequestBody(ContentType = @('application/json'), Required = $true)]
+        [object] $Body
+    )
+
+    Write-KrResponse @{
+        itemId = $id
+        ok = $true
+    }
+}
+
+Add-KrOpenApiRoute
+
+Start-KrServer

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,6 +21,7 @@ Deeper, cross-cutting subjects (logging, deployment, performance, etc.).
 | [Authentication](./authentication) | JWT, OAuth 2.0, OpenID Connect (OIDC), and client certificates (mTLS) |
 | [OpenAPI](./openapi) | Generate and document APIs with OpenAPI 3.0+ specifications |
 | [Dotnet Tool](./tooling) | Install, update, and use the `kestrun` CLI via `Kestrun.Tool` |
+| [MCP Server](./mcp) | Expose Kestrun routes, OpenAPI, runtime inspection, and safe invocation to MCP clients |
 | [Production Deployment (Service/Daemon)](./production-service-daemon) | Deploy custom Kestrun apps to VM/bare-metal service hosts |
 | [Real-time (SSE & SignalR)](./realtime) | Stream events via SSE or build interactive apps with SignalR |
 | [Scheduling](./scheduling) | Background jobs via intervals and CRON (PS & C#) |

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -8,7 +8,8 @@ nav_order: 37
 # Kestrun MCP Server
 
 `Kestrun.Mcp` is a stdio-based Model Context Protocol (MCP) server for local Kestrun apps.
-It starts a Kestrun PowerShell script in-process, inspects the resulting host, and exposes safe MCP tools for route discovery, OpenAPI inspection, runtime inspection, request validation, and optional route invocation.
+It starts a Kestrun PowerShell script in-process, inspects the resulting host, and exposes safe MCP tools for route discovery,
+OpenAPI inspection, runtime inspection, request validation, and optional route invocation.
 
 ## What It Exposes
 
@@ -33,6 +34,40 @@ The default posture is local and non-destructive:
 - Response headers such as `Authorization`, `Cookie`, `Set-Cookie`, and `X-Api-Key` are redacted in tool output.
 - Runtime inspection returns a safe configuration snapshot and does not expose secret values from environment variables, configuration, certificates, or auth tokens.
 
+## Build And Install
+
+`Kestrun.Mcp` is a C# project in this repository and is included in `Kestrun.sln`.
+The repository's standard `Invoke-Build Build` flow stays focused on the main Kestrun artifacts, so the MCP host has its own dedicated build task.
+
+From the repository root, restore dependencies and build the MCP host explicitly:
+
+```powershell
+Invoke-Build Restore
+Invoke-Build Build-KestrunMcp
+```
+
+If you prefer to build the project directly with `dotnet`:
+
+```powershell
+dotnet build .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj
+```
+
+This produces `Kestrun.Mcp.dll` under:
+
+- `src/CSharp/Kestrun.Mcp/bin/Debug/net10.0/`
+- or the matching `Release` output if you build with `-c Release`
+
+## What You Need
+
+To use the MCP server, you need:
+
+- a Kestrun PowerShell script to run
+- the Kestrun module manifest, typically `src/PowerShell/Kestrun/Kestrun.psd1`
+- a stdio-capable MCP client
+- .NET 10 and PowerShell available on the local machine
+
+The server starts the target script in-process, waits for a `KestrunHost`, and then exposes MCP tools against that running host.
+
 ## Run The Server
 
 From the repository root:
@@ -42,6 +77,26 @@ dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
   --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
   --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1
 ```
+
+You can also launch the built DLL directly:
+
+```powershell
+dotnet .\src\CSharp\Kestrun.Mcp\bin\Debug\net10.0\Kestrun.Mcp.dll -- `
+  --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1
+```
+
+## Command-Line Options
+
+The initial command-line surface is:
+
+- `--script <path>`: required path to the Kestrun PowerShell script to run
+- `--kestrun-manifest <path>`: optional explicit `Kestrun.psd1` path
+- `--host-name <name>`: optional named host when the script does not use the default host
+- `--discover-pshome`: let the process discover `PSHOME` instead of setting it explicitly
+- `--allow-invoke <pattern>`: enable `kestrun.invoke_route` and allow a path glob such as `/hello` or `/api/*`
+
+If `--kestrun-manifest` is omitted, `Kestrun.Mcp` tries common local manifest locations before failing.
 
 If the script registers a named host instead of using the default host, add `--host-name`:
 
@@ -62,30 +117,45 @@ dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
   --allow-invoke /api/*
 ```
 
-## Example Script: Hello World
+## Configure A Script For MCP
 
-Sample file: `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1`
+The easiest setup is a normal local Kestrun script that:
 
-With that script running through `Kestrun.Mcp`, an MCP client can call:
+1. creates a server
+2. adds one or more listeners
+3. enables configuration
+4. registers routes
+5. starts the server
 
-- `kestrun.list_routes` to see `/hello`
-- `kestrun.inspect_runtime` to inspect listeners and uptime
-- `kestrun.invoke_route` for `/hello` if `--allow-invoke /hello` is enabled
+Example:
 
-## Example Script: OpenAPI-Aware Route
+```powershell
+param([int]$Port = $env:PORT ?? 5000)
 
-Sample file: `docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1`
+New-KrServer -Name 'MCP Hello'
+Add-KrEndpoint -Port $Port
+Enable-KrConfiguration
 
-This makes `kestrun.get_route` and `kestrun.get_openapi` useful for the same route:
+Add-KrMapRoute -Pattern '/hello' -Verbs Get -ScriptBlock {
+    Write-KrJsonResponse @{ message = 'hello from Kestrun' }
+}
 
-- `kestrun.get_route` returns route metadata plus OpenAPI-derived request and response schemas when available.
-- `kestrun.get_openapi` returns the generated OpenAPI document as structured JSON.
-- `kestrun.validate_request` can explain likely `404`, `406`, or `415` outcomes before you send a request.
+Start-KrServer
+```
 
-## MCP Client Connection
+The same script can still be run normally outside MCP. The MCP host just supplies the process/runtime wrapper around it.
 
-Any MCP-compatible client that supports stdio servers can launch `Kestrun.Mcp`.
-The exact configuration shape depends on the client, but it typically looks like this:
+## Configure An MCP Client
+
+Any MCP client that supports stdio servers can launch `Kestrun.Mcp`.
+The MCP client needs to know:
+
+- the executable to start, usually `dotnet`
+- the arguments needed to launch `Kestrun.Mcp`
+- which script the MCP server should run
+- whether route invocation should be enabled
+
+Typical client configuration:
 
 ```json
 {
@@ -109,9 +179,60 @@ The exact configuration shape depends on the client, but it typically looks like
 }
 ```
 
+If your client prefers launching a built binary instead of `dotnet run`, point it at the built DLL:
+
+```json
+{
+  "mcpServers": {
+    "kestrun": {
+      "command": "dotnet",
+      "args": [
+        "./src/CSharp/Kestrun.Mcp/bin/Debug/net10.0/Kestrun.Mcp.dll",
+        "--script",
+        "./docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1",
+        "--kestrun-manifest",
+        "./src/PowerShell/Kestrun/Kestrun.psd1"
+      ]
+    }
+  }
+}
+```
+
+## How To Use It
+
+Once the MCP client connects, a typical workflow is:
+
+1. Call `kestrun.inspect_runtime` to confirm the host is running and listeners are active.
+2. Call `kestrun.list_routes` to see the registered routes and metadata.
+3. Call `kestrun.get_route` for one route when you need request/response schema detail.
+4. Call `kestrun.get_openapi` when you want the full generated OpenAPI document.
+5. Call `kestrun.validate_request` before invoking a route if you want likely `404`, `406`, or `415` outcomes explained.
+6. Call `kestrun.invoke_route` only for explicitly allowlisted paths.
+
+## Example Script: Hello World
+
+Sample file: `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1`
+
+With that script running through `Kestrun.Mcp`, an MCP client can call:
+
+- `kestrun.list_routes` to see `/hello`
+- `kestrun.inspect_runtime` to inspect listeners and uptime
+- `kestrun.invoke_route` for `/hello` if `--allow-invoke /hello` is enabled
+
+## Example Script: OpenAPI-Aware Route
+
+Sample file: `docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1`
+
+This makes `kestrun.get_route` and `kestrun.get_openapi` useful for the same route:
+
+- `kestrun.get_route` returns route metadata plus OpenAPI-derived request and response schemas when available.
+- `kestrun.get_openapi` returns the generated OpenAPI document as structured JSON.
+- `kestrun.validate_request` can explain likely `404`, `406`, or `415` outcomes before you send a request.
+
 ## Notes
 
 - `kestrun.get_openapi` supports selecting an OpenAPI version such as `2.0`, `3.0`, `3.1`, or `3.2`.
 - `kestrun.get_route` can select a route by pattern and/or operation id.
 - `kestrun.inspect_runtime` reports Kestrun runtime status, start time, uptime, listeners, and a safe configuration snapshot.
-- `kestrun.validate_request` is intended for debugging and agent planning. It predicts likely framework outcomes from route metadata and known content-type / Accept constraints.
+- `kestrun.validate_request` is intended for debugging and agent planning.
+It predicts likely framework outcomes from route metadata and known content-type / Accept constraints.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,117 @@
+---
+layout: default
+title: MCP Server
+parent: Guides
+nav_order: 37
+---
+
+# Kestrun MCP Server
+
+`Kestrun.Mcp` is a stdio-based Model Context Protocol (MCP) server for local Kestrun apps.
+It starts a Kestrun PowerShell script in-process, inspects the resulting host, and exposes safe MCP tools for route discovery, OpenAPI inspection, runtime inspection, request validation, and optional route invocation.
+
+## What It Exposes
+
+The initial tool surface is:
+
+- `kestrun.list_routes`
+- `kestrun.get_route`
+- `kestrun.get_openapi`
+- `kestrun.inspect_runtime`
+- `kestrun.validate_request`
+- `kestrun.invoke_route`
+
+These tools are backed by Kestrun's own route metadata, OpenAPI document generation, and HTTP pipeline.
+`kestrun.invoke_route` sends a real HTTP request to the running Kestrun listener. It does not bypass middleware, routing, validation, or content negotiation.
+
+## Safety Model
+
+The default posture is local and non-destructive:
+
+- `kestrun.invoke_route` is disabled unless you explicitly enable it with one or more `--allow-invoke` patterns.
+- Invocation is limited to allowlisted paths.
+- Response headers such as `Authorization`, `Cookie`, `Set-Cookie`, and `X-Api-Key` are redacted in tool output.
+- Runtime inspection returns a safe configuration snapshot and does not expose secret values from environment variables, configuration, certificates, or auth tokens.
+
+## Run The Server
+
+From the repository root:
+
+```powershell
+dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
+  --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1
+```
+
+If the script registers a named host instead of using the default host, add `--host-name`:
+
+```powershell
+dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
+  --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1 `
+  --host-name MyHost
+```
+
+To enable request invocation for specific routes:
+
+```powershell
+dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
+  --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1 `
+  --allow-invoke /hello `
+  --allow-invoke /api/*
+```
+
+## Example Script: Hello World
+
+Sample file: `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1`
+
+With that script running through `Kestrun.Mcp`, an MCP client can call:
+
+- `kestrun.list_routes` to see `/hello`
+- `kestrun.inspect_runtime` to inspect listeners and uptime
+- `kestrun.invoke_route` for `/hello` if `--allow-invoke /hello` is enabled
+
+## Example Script: OpenAPI-Aware Route
+
+Sample file: `docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1`
+
+This makes `kestrun.get_route` and `kestrun.get_openapi` useful for the same route:
+
+- `kestrun.get_route` returns route metadata plus OpenAPI-derived request and response schemas when available.
+- `kestrun.get_openapi` returns the generated OpenAPI document as structured JSON.
+- `kestrun.validate_request` can explain likely `404`, `406`, or `415` outcomes before you send a request.
+
+## MCP Client Connection
+
+Any MCP-compatible client that supports stdio servers can launch `Kestrun.Mcp`.
+The exact configuration shape depends on the client, but it typically looks like this:
+
+```json
+{
+  "mcpServers": {
+    "kestrun": {
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "./src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj",
+        "--",
+        "--script",
+        "./docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1",
+        "--kestrun-manifest",
+        "./src/PowerShell/Kestrun/Kestrun.psd1",
+        "--allow-invoke",
+        "/hello"
+      ]
+    }
+  }
+}
+```
+
+## Notes
+
+- `kestrun.get_openapi` supports selecting an OpenAPI version such as `2.0`, `3.0`, `3.1`, or `3.2`.
+- `kestrun.get_route` can select a route by pattern and/or operation id.
+- `kestrun.inspect_runtime` reports Kestrun runtime status, start time, uptime, listeners, and a safe configuration snapshot.
+- `kestrun.validate_request` is intended for debugging and agent planning. It predicts likely framework outcomes from route metadata and known content-type / Accept constraints.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -25,6 +25,18 @@ The initial tool surface is:
 These tools are backed by Kestrun's own route metadata, OpenAPI document generation, and HTTP pipeline.
 `kestrun.invoke_route` sends a real HTTP request to the running Kestrun listener. It does not bypass middleware, routing, validation, or content negotiation.
 
+## What You Can Do With It
+
+`Kestrun.Mcp` is most useful when you want an MCP client or coding agent to inspect a live local Kestrun app without reverse-engineering the script by hand.
+
+Typical uses:
+
+- discover the routes a script actually registered, including verbs, tags, summaries, request content types, and response content types
+- inspect one route in detail, including OpenAPI-derived request and response schemas when the route is annotated
+- fetch the generated OpenAPI document as structured JSON instead of scraping `/openapi/...` text output
+- check whether a request is likely to fail with `404`, `406`, or `415` before sending it
+- safely invoke allowlisted local routes through the normal HTTP pipeline for smoke testing and agent workflows
+
 ## Safety Model
 
 The default posture is local and non-destructive:
@@ -209,6 +221,93 @@ Once the MCP client connects, a typical workflow is:
 5. Call `kestrun.validate_request` before invoking a route if you want likely `404`, `406`, or `415` outcomes explained.
 6. Call `kestrun.invoke_route` only for explicitly allowlisted paths.
 
+## Practical Walkthrough: Hello Route
+
+Sample file: `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1`
+
+This script exposes one `GET /hello` route. It is the shortest useful MCP walkthrough because it shows route discovery, runtime inspection, and optional invocation.
+
+Start the MCP server with route invocation enabled for `/hello`:
+
+```powershell
+dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
+  --script .\docs\_includes\examples\pwsh\24.1-Mcp-Hello.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1 `
+  --allow-invoke /hello
+```
+
+Then use the MCP tools in this order.
+
+### 1. Confirm The Runtime Is Ready
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.inspect_runtime",
+  "arguments": {}
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "applicationName": "MCP Hello",
+  "status": "running",
+  "routeCount": 1
+}
+```
+
+### 2. Discover The Registered Route
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.list_routes",
+  "arguments": {}
+}
+```
+
+Typical result excerpt:
+
+```json
+[
+  {
+    "pattern": "/hello",
+    "verbs": ["GET"]
+  }
+]
+```
+
+### 3. Invoke The Route Through Kestrun
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.invoke_route",
+  "arguments": {
+    "method": "GET",
+    "path": "/hello"
+  }
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "statusCode": 200,
+  "contentType": "application/json; charset=utf-8",
+  "body": "{\"message\":\"hello from Kestrun\"}"
+}
+```
+
+That is a real request through the running Kestrun listener. If `/hello` was not included in `--allow-invoke`,
+the same tool call would return a `403` error with code `invoke_not_allowlisted`.
+
 ## Example Script: Hello World
 
 Sample file: `docs/_includes/examples/pwsh/24.1-Mcp-Hello.ps1`
@@ -219,15 +318,192 @@ With that script running through `Kestrun.Mcp`, an MCP client can call:
 - `kestrun.inspect_runtime` to inspect listeners and uptime
 - `kestrun.invoke_route` for `/hello` if `--allow-invoke /hello` is enabled
 
-## Example Script: OpenAPI-Aware Route
+## Practical Walkthrough: OpenAPI-Aware Route
 
 Sample file: `docs/_includes/examples/pwsh/24.2-Mcp-OpenAPI.ps1`
+
+This script exposes a `POST /items/{id}` route with OpenAPI metadata. It is the better example when you want to see how MCP helps an agent inspect schemas,
+validate a request before sending it, and then invoke the route safely.
+
+Start the MCP server with invocation enabled for the route family:
+
+```powershell
+dotnet run --project .\src\CSharp\Kestrun.Mcp\Kestrun.Mcp.csproj -- `
+  --script .\docs\_includes\examples\pwsh\24.2-Mcp-OpenAPI.ps1 `
+  --kestrun-manifest .\src\PowerShell\Kestrun\Kestrun.psd1 `
+  --allow-invoke /items/*
+```
+
+### 1. Inspect A Route By `operationId`
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.get_route",
+  "arguments": {
+    "operationId": "createItem"
+  }
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "route": {
+    "pattern": "/items/{id}",
+    "verbs": ["POST"],
+    "tags": ["items"],
+    "operationId": "createItem"
+  },
+  "requestSchemas": {
+    "application/json": {
+      "type": "object"
+    }
+  }
+}
+```
+
+### 2. Fetch The Generated OpenAPI Document
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.get_openapi",
+  "arguments": {
+    "version": "3.1"
+  }
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "documentId": "Default",
+  "version": "3.1.2",
+  "document": {
+    "openapi": "3.1.2",
+    "paths": {
+      "/items/{id}": {
+        "post": {}
+      }
+    }
+  }
+}
+```
+
+### 3. Validate A Request Before Sending It
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.validate_request",
+  "arguments": {
+    "method": "POST",
+    "path": "/items/42",
+    "headers": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "body": {
+      "name": "widget"
+    }
+  }
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "isValid": true,
+  "statusCode": 200,
+  "message": "The request matches a registered route and satisfies known content-type/accept constraints."
+}
+```
+
+A failure example with an incompatible `Accept` header:
+
+```json
+{
+  "tool": "kestrun.validate_request",
+  "arguments": {
+    "method": "POST",
+    "path": "/items/42",
+    "headers": {
+      "Content-Type": "application/json",
+      "Accept": "text/plain"
+    },
+    "body": {
+      "name": "widget"
+    }
+  }
+}
+```
+
+Typical failure excerpt:
+
+```json
+{
+  "isValid": false,
+  "statusCode": 406,
+  "error": {
+    "code": "not_acceptable"
+  }
+}
+```
+
+### 4. Invoke The Route After Validation
+
+Tool call:
+
+```json
+{
+  "tool": "kestrun.invoke_route",
+  "arguments": {
+    "method": "POST",
+    "path": "/items/42",
+    "headers": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "body": {
+      "name": "widget"
+    }
+  }
+}
+```
+
+Typical result excerpt:
+
+```json
+{
+  "statusCode": 200,
+  "contentType": "application/json; charset=utf-8",
+  "body": "{\"itemId\":42,\"ok\":true}"
+}
+```
 
 This makes `kestrun.get_route` and `kestrun.get_openapi` useful for the same route:
 
 - `kestrun.get_route` returns route metadata plus OpenAPI-derived request and response schemas when available.
 - `kestrun.get_openapi` returns the generated OpenAPI document as structured JSON.
 - `kestrun.validate_request` can explain likely `404`, `406`, or `415` outcomes before you send a request.
+- `kestrun.invoke_route` returns response headers too, but sensitive values such as `Set-Cookie` are redacted when present.
+
+## Example Agent Tasks
+
+Once the MCP server is connected, these are realistic things to ask an MCP-capable agent to do:
+
+- "List the routes in my Kestrun script and tell me which ones accept JSON."
+- "Show me the OpenAPI schema for `createItem`."
+- "Check why `POST /items/42` with `Accept: text/plain` would fail."
+- "Invoke `/hello` and summarize the JSON response."
+- "Fetch the OpenAPI 3.1 document and compare it with the route metadata for `/items/{id}`."
 
 ## Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ It combines the performance of C# with the flexibility of PowerShell, making it 
 - 📚 **Tutorials**: [pwsh/tutorial/](/pwsh/tutorial/)
 - 📘 **Guides**: [guides/](/guides/)
 - 🛠️ **Dotnet Tool**: [Kestrun CLI (`Kestrun.Tool`)](/guides/tooling)
+- 🤖 **MCP Server**: [Kestrun MCP Guide](/guides/mcp)
 
 ## Getting started
 
@@ -63,6 +64,7 @@ Use the [Guides](/guides/) to add real-world features:
 - Authentication (JWT, API keys, etc.)
 - Logging and observability
 - OpenAPI documentation and UI
+- MCP-based runtime inspection and local agent tooling
 
 ### 3. Run and test locally
 

--- a/src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj
+++ b/src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <AssemblyName>Kestrun.Mcp</AssemblyName>
+        <RootNamespace>Kestrun.Mcp.ServerHost</RootNamespace>
+        <AssemblyTitle>Kestrun.Mcp</AssemblyTitle>
+        <Product>Kestrun.Mcp</Product>
+        <Description>Model Context Protocol server for Kestrun route, OpenAPI, runtime, and safe invocation tools.</Description>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Kestrun\Kestrun.csproj" />
+        <ProjectReference Include="..\Kestrun.Runner\Kestrun.Runner.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/CSharp/Kestrun.Mcp/KestrunMcpCommandLine.cs
+++ b/src/CSharp/Kestrun.Mcp/KestrunMcpCommandLine.cs
@@ -1,0 +1,125 @@
+namespace Kestrun.Mcp.ServerHost;
+
+/// <summary>
+/// Parsed command-line options for the Kestrun MCP server.
+/// </summary>
+internal sealed record KestrunMcpCommandLine(
+    string ScriptPath,
+    string ModuleManifestPath,
+    string? HostName,
+    bool DiscoverPowerShellHome,
+    bool AllowInvokeRoute,
+    IReadOnlyList<string> AllowedInvokePaths)
+{
+    /// <summary>
+    /// Parses command-line arguments into server options.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>The parsed options, or null when parsing fails.</returns>
+    public static KestrunMcpCommandLine? Parse(string[] args)
+    {
+        string? scriptPath = null;
+        string? manifestPath = null;
+        string? hostName = null;
+        var discoverPowerShellHome = false;
+        var allowInvokeRoute = false;
+        var allowedInvokePaths = new List<string>();
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--script":
+                    scriptPath = ReadValue(args, ref index, "--script");
+                    break;
+                case "--kestrun-manifest":
+                    manifestPath = ReadValue(args, ref index, "--kestrun-manifest");
+                    break;
+                case "--host-name":
+                    hostName = ReadValue(args, ref index, "--host-name");
+                    break;
+                case "--discover-pshome":
+                    discoverPowerShellHome = true;
+                    break;
+                case "--allow-invoke":
+                    allowInvokeRoute = true;
+                    allowedInvokePaths.Add(ReadValue(args, ref index, "--allow-invoke"));
+                    break;
+                case "--help":
+                case "-h":
+                    PrintUsage();
+                    return null;
+                default:
+                    throw new InvalidOperationException($"Unknown argument '{args[index]}'.");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(scriptPath))
+        {
+            PrintUsage("Missing required --script argument.");
+            return null;
+        }
+
+        manifestPath ??= ResolveDefaultManifestPath();
+        if (string.IsNullOrWhiteSpace(manifestPath))
+        {
+            throw new InvalidOperationException("Unable to resolve a default Kestrun module manifest path. Provide --kestrun-manifest.");
+        }
+
+        return new KestrunMcpCommandLine(
+            Path.GetFullPath(scriptPath),
+            Path.GetFullPath(manifestPath),
+            hostName,
+            discoverPowerShellHome,
+            allowInvokeRoute,
+            allowInvokeRoute ? allowedInvokePaths : []);
+    }
+
+    /// <summary>
+    /// Reads a required option value.
+    /// </summary>
+    /// <param name="args">All arguments.</param>
+    /// <param name="index">The current argument index.</param>
+    /// <param name="optionName">The option name.</param>
+    /// <returns>The required value.</returns>
+    private static string ReadValue(string[] args, ref int index, string optionName)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new InvalidOperationException($"Missing value for {optionName}.");
+        }
+
+        index++;
+        return args[index];
+    }
+
+    /// <summary>
+    /// Resolves a default Kestrun module manifest path.
+    /// </summary>
+    /// <returns>The manifest path when found; otherwise null.</returns>
+    private static string? ResolveDefaultManifestPath()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "Modules", "Kestrun", "Kestrun.psd1"),
+            Path.Combine(AppContext.BaseDirectory, "Kestrun.psd1"),
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "src", "PowerShell", "Kestrun", "Kestrun.psd1"))
+        };
+
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    /// <summary>
+    /// Prints usage help to stderr.
+    /// </summary>
+    /// <param name="error">Optional parse error.</param>
+    private static void PrintUsage(string? error = null)
+    {
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            Console.Error.WriteLine(error);
+        }
+
+        Console.Error.WriteLine("Usage: Kestrun.Mcp --script <path> [--kestrun-manifest <path>] [--host-name <name>] [--discover-pshome] [--allow-invoke <glob> ...]");
+    }
+}

--- a/src/CSharp/Kestrun.Mcp/KestrunMcpRuntime.cs
+++ b/src/CSharp/Kestrun.Mcp/KestrunMcpRuntime.cs
@@ -1,0 +1,162 @@
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using Kestrun.Hosting;
+using Kestrun.Runner;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Kestrun.Mcp.ServerHost;
+
+/// <summary>
+/// Holds the live Kestrun host for MCP tool access.
+/// </summary>
+internal sealed class KestrunMcpRuntime
+{
+    private readonly TaskCompletionSource<KestrunHost> _hostSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Completes the runtime with a resolved Kestrun host.
+    /// </summary>
+    /// <param name="host">The resolved host.</param>
+    public void SetHost(KestrunHost host) => _hostSource.TrySetResult(host);
+
+    /// <summary>
+    /// Completes the runtime with an error.
+    /// </summary>
+    /// <param name="exception">The startup exception.</param>
+    public void SetException(Exception exception) => _hostSource.TrySetException(exception);
+
+    /// <summary>
+    /// Waits for the Kestrun host to become available.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved host.</returns>
+    public Task<KestrunHost> WaitForHostAsync(CancellationToken cancellationToken)
+        => _hostSource.Task.WaitAsync(cancellationToken);
+}
+
+/// <summary>
+/// Executes the target Kestrun script in-process and publishes the resulting host.
+/// </summary>
+internal sealed class KestrunScriptSessionHostedService(
+    KestrunMcpCommandLine options,
+    KestrunMcpRuntime runtime,
+    ILogger<KestrunScriptSessionHostedService> logger,
+    IHostApplicationLifetime appLifetime) : IHostedService
+{
+    private Task? _executionTask;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _executionTask = Task.Run(() => ExecuteAsync(appLifetime.ApplicationStopping), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await RunnerRuntime.RequestManagedStopAsync().ConfigureAwait(false);
+        if (_executionTask is not null)
+        {
+            await _executionTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Executes the configured script and waits for the host to become available.
+    /// </summary>
+    /// <param name="stopToken">Application stop token.</param>
+    /// <returns>A task that completes when the script exits.</returns>
+    private async Task ExecuteAsync(CancellationToken stopToken)
+    {
+        try
+        {
+            RunnerRuntime.EnsureNet10Runtime("Kestrun.Mcp");
+            ConfigurePowerShellHome();
+            RunnerRuntime.EnsurePowerShellRuntimeHome(createFallbackDirectories: true);
+            RunnerRuntime.EnsureKestrunAssemblyPreloaded(options.ModuleManifestPath, message => logger.LogWarning("{Message}", message));
+
+            using var runspace = CreateRunspace();
+            using var powershell = PowerShell.Create();
+            powershell.Runspace = runspace;
+            runspace.SessionStateProxy.SetVariable("__krRunnerScriptPath", options.ScriptPath);
+            runspace.SessionStateProxy.SetVariable("__krRunnerManagedConsole", true);
+            runspace.SessionStateProxy.SetVariable("__krRunnerQuiet", true);
+            _ = powershell.AddScript(". $__krRunnerScriptPath", useLocalScope: false);
+
+            logger.LogInformation("Starting Kestrun script '{ScriptPath}'.", options.ScriptPath);
+            var asyncResult = powershell.BeginInvoke();
+
+            while (!asyncResult.IsCompleted)
+            {
+                ResolveHostIfAvailable();
+                _ = asyncResult.AsyncWaitHandle.WaitOne(200);
+                if (stopToken.IsCancellationRequested)
+                {
+                    await RunnerRuntime.RequestManagedStopAsync().ConfigureAwait(false);
+                }
+            }
+
+            _ = powershell.EndInvoke(asyncResult);
+            ResolveHostIfAvailable();
+
+            if (powershell.HadErrors)
+            {
+                var errorMessage = string.Join(Environment.NewLine, powershell.Streams.Error.Select(static error => error.ToString()));
+                throw new InvalidOperationException($"Kestrun script completed with errors:{Environment.NewLine}{errorMessage}");
+            }
+        }
+        catch (Exception ex)
+        {
+            runtime.SetException(ex);
+            logger.LogError(ex, "Failed to start the Kestrun MCP runtime.");
+            appLifetime.StopApplication();
+        }
+    }
+
+    /// <summary>
+    /// Creates the runspace used for script execution.
+    /// </summary>
+    /// <returns>An opened runspace.</returns>
+    private Runspace CreateRunspace()
+    {
+        var sessionState = InitialSessionState.CreateDefault2();
+        sessionState.ImportPSModule([options.ModuleManifestPath]);
+        var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        return runspace;
+    }
+
+    /// <summary>
+    /// Resolves the configured host from <see cref="KestrunHostManager"/> when available.
+    /// </summary>
+    private void ResolveHostIfAvailable()
+    {
+        var host = string.IsNullOrWhiteSpace(options.HostName)
+            ? KestrunHostManager.Default
+            : KestrunHostManager.Get(options.HostName);
+
+        if (host is not null)
+        {
+            runtime.SetHost(host);
+        }
+    }
+
+    /// <summary>
+    /// Configures PSHOME for embedded execution.
+    /// </summary>
+    private void ConfigurePowerShellHome()
+    {
+        if (options.DiscoverPowerShellHome)
+        {
+            logger.LogInformation("PSHOME discovery mode enabled.");
+            return;
+        }
+
+        var manifestDirectory = Path.GetDirectoryName(options.ModuleManifestPath);
+        var moduleRoot = manifestDirectory is null ? null : Directory.GetParent(manifestDirectory);
+        var serviceRoot = moduleRoot?.Parent?.FullName ?? AppContext.BaseDirectory;
+        Environment.SetEnvironmentVariable("PSHOME", serviceRoot);
+    }
+}

--- a/src/CSharp/Kestrun.Mcp/KestrunMcpRuntime.cs
+++ b/src/CSharp/Kestrun.Mcp/KestrunMcpRuntime.cs
@@ -106,6 +106,8 @@ internal sealed class KestrunScriptSessionHostedService(
                 var errorMessage = string.Join(Environment.NewLine, powershell.Streams.Error.Select(static error => error.ToString()));
                 throw new InvalidOperationException($"Kestrun script completed with errors:{Environment.NewLine}{errorMessage}");
             }
+
+            EnsureHostResolved();
         }
         catch (Exception ex)
         {
@@ -133,15 +135,42 @@ internal sealed class KestrunScriptSessionHostedService(
     /// </summary>
     private void ResolveHostIfAvailable()
     {
-        var host = string.IsNullOrWhiteSpace(options.HostName)
-            ? KestrunHostManager.Default
-            : KestrunHostManager.Get(options.HostName);
+        var host = TryResolveHost();
 
         if (host is not null)
         {
             runtime.SetHost(host);
         }
     }
+
+    /// <summary>
+    /// Ensures the configured host was discovered after script execution completed.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the expected host was never registered.</exception>
+    private void EnsureHostResolved()
+    {
+        if (TryResolveHost() is not null)
+        {
+            return;
+        }
+
+        var hostLabel = string.IsNullOrWhiteSpace(options.HostName)
+            ? "the default Kestrun host"
+            : $"Kestrun host '{options.HostName}'";
+
+        throw new InvalidOperationException(
+            $"The script '{options.ScriptPath}' completed without registering {hostLabel}. " +
+            "Ensure the script creates and starts the expected Kestrun host.");
+    }
+
+    /// <summary>
+    /// Resolves the configured host from <see cref="KestrunHostManager"/>.
+    /// </summary>
+    /// <returns>The resolved host when available; otherwise, <see langword="null"/>.</returns>
+    private KestrunHost? TryResolveHost()
+        => string.IsNullOrWhiteSpace(options.HostName)
+            ? KestrunHostManager.Default
+            : KestrunHostManager.Get(options.HostName);
 
     /// <summary>
     /// Configures PSHOME for embedded execution.

--- a/src/CSharp/Kestrun.Mcp/KestrunMcpTools.cs
+++ b/src/CSharp/Kestrun.Mcp/KestrunMcpTools.cs
@@ -1,0 +1,142 @@
+using System.ComponentModel;
+using Kestrun.Mcp;
+using ModelContextProtocol.Server;
+
+namespace Kestrun.Mcp.ServerHost;
+
+/// <summary>
+/// MCP tool surface for inspecting a live Kestrun host.
+/// </summary>
+[McpServerToolType]
+internal sealed class KestrunMcpTools(
+    KestrunMcpRuntime runtime,
+    IKestrunRouteInspector routeInspector,
+    IKestrunOpenApiProvider openApiProvider,
+    IKestrunRuntimeInspector runtimeInspector,
+    IKestrunRequestValidator requestValidator,
+    IKestrunRequestInvoker requestInvoker)
+{
+    private readonly KestrunMcpRuntime _runtime = runtime;
+    private readonly IKestrunRouteInspector _routeInspector = routeInspector;
+    private readonly IKestrunOpenApiProvider _openApiProvider = openApiProvider;
+    private readonly IKestrunRuntimeInspector _runtimeInspector = runtimeInspector;
+    private readonly IKestrunRequestValidator _requestValidator = requestValidator;
+    private readonly IKestrunRequestInvoker _requestInvoker = requestInvoker;
+
+    /// <summary>
+    /// Lists registered Kestrun routes.
+    /// </summary>
+    /// <returns>Registered route summaries.</returns>
+    [McpServerTool(Name = "kestrun.list_routes", UseStructuredContent = true), Description("Return all registered Kestrun routes with route, OpenAPI, and handler metadata.")]
+    public async Task<IReadOnlyList<KestrunRouteSummary>> ListRoutes(CancellationToken cancellationToken)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return _routeInspector.ListRoutes(host);
+    }
+
+    /// <summary>
+    /// Returns route metadata for one selected route.
+    /// </summary>
+    /// <param name="pattern">Route pattern to inspect.</param>
+    /// <param name="operationId">OpenAPI operation identifier to inspect.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Detailed route metadata.</returns>
+    [McpServerTool(Name = "kestrun.get_route", UseStructuredContent = true), Description("Return detailed metadata for a single Kestrun route selected by pattern and/or operation id.")]
+    public async Task<KestrunRouteDetail> GetRoute(
+        [Description("Route pattern to inspect, for example /hello or /api/items/{id}.")] string? pattern = null,
+        [Description("OpenAPI operation id to inspect.")] string? operationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return _routeInspector.GetRoute(host, pattern, operationId);
+    }
+
+    /// <summary>
+    /// Returns a structured OpenAPI document.
+    /// </summary>
+    /// <param name="version">Requested OpenAPI version such as 3.0, 3.1, or 3.2.</param>
+    /// <param name="documentId">Requested document id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The structured OpenAPI document.</returns>
+    [McpServerTool(Name = "kestrun.get_openapi", UseStructuredContent = true), Description("Return the generated Kestrun OpenAPI document as structured JSON.")]
+    public async Task<KestrunOpenApiDocumentResult> GetOpenApi(
+        [Description("Requested OpenAPI version such as 3.0, 3.1, or 3.2.")] string? version = null,
+        [Description("OpenAPI document id. Omit to use the default document.")] string? documentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return _openApiProvider.GetOpenApi(host, documentId, version);
+    }
+
+    /// <summary>
+    /// Returns a safe runtime summary.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The runtime summary.</returns>
+    [McpServerTool(Name = "kestrun.inspect_runtime", UseStructuredContent = true), Description("Return safe Kestrun runtime information such as status, uptime, listeners, and non-sensitive configuration.")]
+    public async Task<KestrunRuntimeInspectionResult> InspectRuntime(CancellationToken cancellationToken)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return _runtimeInspector.Inspect(host);
+    }
+
+    /// <summary>
+    /// Validates a proposed request against the selected Kestrun host.
+    /// </summary>
+    /// <param name="method">HTTP method.</param>
+    /// <param name="path">Request path.</param>
+    /// <param name="headers">Optional headers.</param>
+    /// <param name="query">Optional query values.</param>
+    /// <param name="body">Optional request body.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The validation result.</returns>
+    [McpServerTool(Name = "kestrun.validate_request", UseStructuredContent = true), Description("Validate whether a proposed request would satisfy Kestrun route matching, content-type, and Accept constraints.")]
+    public async Task<KestrunRequestValidationResult> ValidateRequest(
+        [Description("HTTP method to validate.")] string method,
+        [Description("Route path to validate.")] string path,
+        [Description("Optional request headers.")] IDictionary<string, string>? headers = null,
+        [Description("Optional query-string values.")] IDictionary<string, string>? query = null,
+        [Description("Optional request body.")] object? body = null,
+        CancellationToken cancellationToken = default)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return _requestValidator.Validate(host, new KestrunRequestInput
+        {
+            Method = method,
+            Path = path,
+            Headers = headers,
+            Query = query,
+            Body = body
+        });
+    }
+
+    /// <summary>
+    /// Invokes a route through the normal HTTP pipeline.
+    /// </summary>
+    /// <param name="method">HTTP method.</param>
+    /// <param name="path">Request path.</param>
+    /// <param name="headers">Optional headers.</param>
+    /// <param name="query">Optional query values.</param>
+    /// <param name="body">Optional request body.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The invocation result.</returns>
+    [McpServerTool(Name = "kestrun.invoke_route", UseStructuredContent = true), Description("Safely invoke a Kestrun route through the normal HTTP pipeline when invocation is explicitly enabled.")]
+    public async Task<KestrunRouteInvokeResult> InvokeRoute(
+        [Description("HTTP method to invoke.")] string method,
+        [Description("Route path to invoke.")] string path,
+        [Description("Optional request headers.")] IDictionary<string, string>? headers = null,
+        [Description("Optional query-string values.")] IDictionary<string, string>? query = null,
+        [Description("Optional request body.")] object? body = null,
+        CancellationToken cancellationToken = default)
+    {
+        var host = await _runtime.WaitForHostAsync(cancellationToken).ConfigureAwait(false);
+        return await _requestInvoker.InvokeAsync(host, new KestrunRequestInput
+        {
+            Method = method,
+            Path = path,
+            Headers = headers,
+            Query = query,
+            Body = body
+        }, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/CSharp/Kestrun.Mcp/Program.cs
+++ b/src/CSharp/Kestrun.Mcp/Program.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Kestrun.Mcp;
+using Kestrun.Mcp.ServerHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+var options = KestrunMcpCommandLine.Parse(args);
+if (options is null)
+{
+    return 1;
+}
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(console =>
+{
+    console.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services.AddSingleton(options);
+builder.Services.AddSingleton<KestrunMcpRuntime>();
+builder.Services.AddSingleton<IKestrunRouteInspector, KestrunRouteInspector>();
+builder.Services.AddSingleton<IKestrunOpenApiProvider, KestrunOpenApiProvider>();
+builder.Services.AddSingleton<IKestrunRuntimeInspector, KestrunRuntimeInspector>();
+builder.Services.AddSingleton<IKestrunRequestValidator, KestrunRequestValidator>();
+builder.Services.AddSingleton(new KestrunRequestInvokerOptions
+{
+    EnableInvocation = options.AllowInvokeRoute,
+    AllowedPathPatterns = options.AllowedInvokePaths
+});
+builder.Services.AddSingleton<IKestrunRequestInvoker, KestrunRequestInvoker>();
+builder.Services.AddHostedService<KestrunScriptSessionHostedService>();
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly(Assembly.GetExecutingAssembly());
+
+await builder.Build().RunAsync();
+return 0;

--- a/src/CSharp/Kestrun.Mcp/Properties/AssemblyInfo.cs
+++ b/src/CSharp/Kestrun.Mcp/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Kestrun.Mcp.Tests")]

--- a/src/CSharp/Kestrun/Hosting/KestrunHost.cs
+++ b/src/CSharp/Kestrun/Hosting/KestrunHost.cs
@@ -2266,6 +2266,47 @@ public partial class KestrunHost : IDisposable
         }
     }
 
+    /// <summary>
+    /// Gets the currently known application URLs for this host.
+    /// </summary>
+    public IReadOnlyList<string> CurrentUrls
+    {
+        get
+        {
+            if (_app is { Urls.Count: > 0 })
+            {
+                return [.. _app.Urls];
+            }
+
+            return
+            [
+                .. Options.Listeners.Select(static listener =>
+                    $"{(listener.UseHttps ? "https" : "http")}://{FormatListenerHost(listener.IPAddress)}:{listener.Port}")
+            ];
+        }
+    }
+
+    /// <summary>
+    /// Formats a listener IP address into a URL-safe host literal.
+    /// </summary>
+    /// <param name="address">The listener IP address.</param>
+    /// <returns>A URL-safe host literal.</returns>
+    private static string FormatListenerHost(IPAddress address)
+    {
+        if (Equals(address, IPAddress.Any))
+        {
+            return "0.0.0.0";
+        }
+
+        if (Equals(address, IPAddress.IPv6Any))
+        {
+            return "[::]";
+        }
+
+        var text = address.ToString();
+        return address.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{text}]" : text;
+    }
+
     #endregion
 
     #region Runspace Pool Management

--- a/src/CSharp/Kestrun/Hosting/KestrunHostMapExtensions.cs
+++ b/src/CSharp/Kestrun/Hosting/KestrunHostMapExtensions.cs
@@ -109,6 +109,13 @@ public static partial class KestrunHostMapExtensions
             throw new ArgumentException("Pattern cannot be null or empty.", nameof(options.Pattern));
         }
 
+        if (options.HttpVerbs.Count == 0)
+        {
+            options.HttpVerbs = [HttpVerb.Get];
+        }
+
+        options.ScriptCode.Language = ScriptLanguage.Native;
+
         string[] methods = [.. options.HttpVerbs.Select(v => v.ToMethodString())];
         map = host.App.MapMethods(options.Pattern, methods, async context =>
          {
@@ -126,6 +133,11 @@ public static partial class KestrunHostMapExtensions
          });
 
         host.AddMapOptions(map, options);
+        var registeredPattern = NormalizeCatchAllPattern(options.Pattern);
+        foreach (var method in options.HttpVerbs)
+        {
+            host._registeredRoutes[(registeredPattern, method)] = options;
+        }
 
         host.Logger.Information("Added native route: {Pattern} with methods: {Methods}", options.Pattern, string.Join(", ", methods));
         // Add to the feature queue for later processing

--- a/src/CSharp/Kestrun/Hosting/Options/MapRouteOptions.cs
+++ b/src/CSharp/Kestrun/Hosting/Options/MapRouteOptions.cs
@@ -87,6 +87,10 @@ public class MapRouteOptions
     /// </summary>
     public LanguageOptions ScriptCode { get; init; } = new LanguageOptions();
     /// <summary>
+    /// Best-effort handler identity for the route when a named source is available.
+    /// </summary>
+    public string? HandlerName { get; set; }
+    /// <summary>
     /// If true, throws an exception on duplicate routes.
     /// </summary>
     public bool ThrowOnDuplicate { get; set; }

--- a/src/CSharp/Kestrun/Mcp/KestrunMcpModels.cs
+++ b/src/CSharp/Kestrun/Mcp/KestrunMcpModels.cs
@@ -1,0 +1,240 @@
+using System.Text.Json.Nodes;
+using Kestrun.Hosting;
+namespace Kestrun.Mcp;
+
+/// <summary>
+/// Structured error information returned by Kestrun MCP services.
+/// </summary>
+/// <param name="Code">Stable error code.</param>
+/// <param name="Message">Human-readable explanation.</param>
+/// <param name="Details">Optional machine-readable details.</param>
+public sealed record KestrunMcpError(
+    string Code,
+    string Message,
+    IReadOnlyDictionary<string, object?>? Details = null);
+
+/// <summary>
+/// Summarized route metadata for MCP discovery operations.
+/// </summary>
+public sealed record KestrunRouteSummary
+{
+    /// <summary>Route pattern.</summary>
+    public required string Pattern { get; init; }
+    /// <summary>HTTP methods.</summary>
+    public required IReadOnlyList<string> Verbs { get; init; }
+    /// <summary>OpenAPI tags.</summary>
+    public required IReadOnlyList<string> Tags { get; init; }
+    /// <summary>OpenAPI summary.</summary>
+    public string? Summary { get; init; }
+    /// <summary>OpenAPI description.</summary>
+    public string? Description { get; init; }
+    /// <summary>Supported request content types.</summary>
+    public required IReadOnlyList<string> RequestContentTypes { get; init; }
+    /// <summary>Supported response content types.</summary>
+    public required IReadOnlyList<string> ResponseContentTypes { get; init; }
+    /// <summary>Bound handler name when available.</summary>
+    public string? HandlerName { get; init; }
+    /// <summary>Best-effort script/runtime language.</summary>
+    public string? HandlerLanguage { get; init; }
+    /// <summary>OpenAPI operation identifier when available.</summary>
+    public string? OperationId { get; init; }
+}
+
+/// <summary>
+/// Detailed route metadata for a single route selection.
+/// </summary>
+public sealed record KestrunRouteDetail
+{
+    /// <summary>Route summary payload.</summary>
+    public required KestrunRouteSummary Route { get; init; }
+    /// <summary>Request schema keyed by content type when available.</summary>
+    public required IReadOnlyDictionary<string, JsonNode?> RequestSchemas { get; init; }
+    /// <summary>Response metadata keyed by status code.</summary>
+    public required IReadOnlyDictionary<string, KestrunRouteResponseSchema> Responses { get; init; }
+    /// <summary>Route lookup error when selection fails.</summary>
+    public KestrunMcpError? Error { get; init; }
+}
+
+/// <summary>
+/// Response metadata extracted from OpenAPI.
+/// </summary>
+public sealed record KestrunRouteResponseSchema
+{
+    /// <summary>Response description.</summary>
+    public string? Description { get; init; }
+    /// <summary>Response schemas keyed by content type.</summary>
+    public required IReadOnlyDictionary<string, JsonNode?> Content { get; init; }
+}
+
+/// <summary>
+/// Structured OpenAPI document payload.
+/// </summary>
+public sealed record KestrunOpenApiDocumentResult
+{
+    /// <summary>Requested document id.</summary>
+    public required string DocumentId { get; init; }
+    /// <summary>Resolved OpenAPI version string.</summary>
+    public required string Version { get; init; }
+    /// <summary>Structured document payload.</summary>
+    public JsonNode? Document { get; init; }
+    /// <summary>Lookup error when retrieval fails.</summary>
+    public KestrunMcpError? Error { get; init; }
+}
+
+/// <summary>
+/// Listener metadata exposed through runtime inspection.
+/// </summary>
+public sealed record KestrunRuntimeListener
+{
+    /// <summary>Listener URL.</summary>
+    public required string Url { get; init; }
+    /// <summary>Transport protocols.</summary>
+    public required string Protocols { get; init; }
+    /// <summary>Whether HTTPS is enabled.</summary>
+    public bool UseHttps { get; init; }
+}
+
+/// <summary>
+/// Safe runtime inspection payload.
+/// </summary>
+public sealed record KestrunRuntimeInspectionResult
+{
+    /// <summary>Application name.</summary>
+    public required string ApplicationName { get; init; }
+    /// <summary>Host status.</summary>
+    public required string Status { get; init; }
+    /// <summary>Environment name.</summary>
+    public required string Environment { get; init; }
+    /// <summary>Start timestamp in UTC.</summary>
+    public DateTime? StartTimeUtc { get; init; }
+    /// <summary>Stop timestamp in UTC.</summary>
+    public DateTime? StopTimeUtc { get; init; }
+    /// <summary>Current uptime when available.</summary>
+    public TimeSpan? Uptime { get; init; }
+    /// <summary>Known listeners.</summary>
+    public required IReadOnlyList<KestrunRuntimeListener> Listeners { get; init; }
+    /// <summary>Known route count.</summary>
+    public int RouteCount { get; init; }
+    /// <summary>Selected safe configuration values.</summary>
+    public required IReadOnlyDictionary<string, object?> Configuration { get; init; }
+}
+
+/// <summary>
+/// Proposed request payload used by validation and invocation tools.
+/// </summary>
+public sealed record KestrunRequestInput
+{
+    /// <summary>HTTP method.</summary>
+    public string Method { get; init; } = "GET";
+    /// <summary>Request path.</summary>
+    public string Path { get; init; } = "/";
+    /// <summary>Request headers.</summary>
+    public IDictionary<string, string>? Headers { get; init; }
+    /// <summary>Request query values.</summary>
+    public IDictionary<string, string>? Query { get; init; }
+    /// <summary>Request body.</summary>
+    public object? Body { get; init; }
+}
+
+/// <summary>
+/// Request validation result.
+/// </summary>
+public sealed record KestrunRequestValidationResult
+{
+    /// <summary>Whether the request would likely succeed.</summary>
+    public bool IsValid { get; init; }
+    /// <summary>Likely resulting status code.</summary>
+    public int StatusCode { get; init; }
+    /// <summary>Best-effort explanation.</summary>
+    public required string Message { get; init; }
+    /// <summary>Matched route summary when available.</summary>
+    public KestrunRouteSummary? Route { get; init; }
+    /// <summary>Validation error details.</summary>
+    public KestrunMcpError? Error { get; init; }
+}
+
+/// <summary>
+/// Route invocation result returned by the safe invoker.
+/// </summary>
+public sealed record KestrunRouteInvokeResult
+{
+    /// <summary>Response status code.</summary>
+    public int StatusCode { get; init; }
+    /// <summary>Response content type.</summary>
+    public string? ContentType { get; init; }
+    /// <summary>Response headers.</summary>
+    public required IReadOnlyDictionary<string, string> Headers { get; init; }
+    /// <summary>Response body text.</summary>
+    public string? Body { get; init; }
+    /// <summary>Invocation error details.</summary>
+    public KestrunMcpError? Error { get; init; }
+}
+
+/// <summary>
+/// Configures safety boundaries for the MCP request invoker.
+/// </summary>
+public sealed record KestrunRequestInvokerOptions
+{
+    /// <summary>Whether route invocation is enabled.</summary>
+    public bool EnableInvocation { get; init; }
+    /// <summary>Allowlisted route patterns for invocation.</summary>
+    public IReadOnlyList<string> AllowedPathPatterns { get; init; } = [];
+    /// <summary>Headers to redact in tool output.</summary>
+    public IReadOnlySet<string> RedactedHeaders { get; init; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Authorization",
+            "Cookie",
+            "Set-Cookie",
+            "Proxy-Authorization",
+            "X-Api-Key",
+            "Api-Key"
+        };
+}
+
+/// <summary>
+/// Route inspection contract used by MCP tool handlers.
+/// </summary>
+public interface IKestrunRouteInspector
+{
+    /// <summary>Returns all registered routes.</summary>
+    IReadOnlyList<KestrunRouteSummary> ListRoutes(KestrunHost host);
+    /// <summary>Returns one selected route.</summary>
+    KestrunRouteDetail GetRoute(KestrunHost host, string? pattern = null, string? operationId = null);
+}
+
+/// <summary>
+/// OpenAPI retrieval contract used by MCP tool handlers.
+/// </summary>
+public interface IKestrunOpenApiProvider
+{
+    /// <summary>Returns the requested OpenAPI document.</summary>
+    KestrunOpenApiDocumentResult GetOpenApi(KestrunHost host, string? documentId = null, string? version = null);
+}
+
+/// <summary>
+/// Runtime inspection contract used by MCP tool handlers.
+/// </summary>
+public interface IKestrunRuntimeInspector
+{
+    /// <summary>Returns a safe runtime summary.</summary>
+    KestrunRuntimeInspectionResult Inspect(KestrunHost host);
+}
+
+/// <summary>
+/// Request validation contract used by MCP tool handlers.
+/// </summary>
+public interface IKestrunRequestValidator
+{
+    /// <summary>Validates a proposed request without executing the route handler.</summary>
+    KestrunRequestValidationResult Validate(KestrunHost host, KestrunRequestInput input);
+}
+
+/// <summary>
+/// Request invocation contract used by MCP tool handlers.
+/// </summary>
+public interface IKestrunRequestInvoker
+{
+    /// <summary>Invokes a route through the normal HTTP pipeline.</summary>
+    Task<KestrunRouteInvokeResult> InvokeAsync(KestrunHost host, KestrunRequestInput input, CancellationToken cancellationToken = default);
+}

--- a/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
+++ b/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
@@ -194,6 +194,7 @@ public sealed class KestrunRouteInspector : IKestrunRouteInspector
         }
 
         // Convert each response status code to a KestrunRouteResponseSchema
+#pragma warning disable IDE0028 // Simplify collection initialization
         return responses.ToDictionary(
             static entry => entry.Key,
             static entry => new KestrunRouteResponseSchema
@@ -203,9 +204,10 @@ public sealed class KestrunRouteInspector : IKestrunRouteInspector
                     static item => item.Key,
                     static item => ToJsonNode(item.Value.Schema),
                     StringComparer.OrdinalIgnoreCase)
-                    ?? [with(StringComparer.OrdinalIgnoreCase)]
+                    ?? new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase)
             },
             StringComparer.OrdinalIgnoreCase);
+#pragma warning restore IDE0028 // Simplify collection initialization
     }
 
     /// <summary>
@@ -563,7 +565,7 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
     /// <returns>A normalized header dictionary.</returns>
     private static Dictionary<string, string> NormalizeHeaders(IDictionary<string, string>? headers)
         => headers is null
-            ? [with(StringComparer.OrdinalIgnoreCase)]
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>

--- a/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
+++ b/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
@@ -9,7 +9,6 @@ using Kestrun.Hosting.Options;
 using Kestrun.OpenApi;
 using Kestrun.Runtime;
 using Kestrun.Utilities;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi;
@@ -167,11 +166,12 @@ public sealed class KestrunRouteInspector : IKestrunRouteInspector
     {
         var metadata = route.OpenAPI.Values.FirstOrDefault();
         var requestBody = metadata?.RequestBody;
+        // If there is no request body, return an empty dictionary
         if (requestBody?.Content is null || requestBody.Content.Count == 0)
         {
             return new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase);
         }
-
+        // Convert each request body content type to a JSON node
         return requestBody.Content.ToDictionary(
             static entry => entry.Key,
             static entry => ToJsonNode(entry.Value.Schema),
@@ -187,11 +187,13 @@ public sealed class KestrunRouteInspector : IKestrunRouteInspector
     {
         var metadata = route.OpenAPI.Values.FirstOrDefault();
         var responses = metadata?.Responses;
+        // If there are no responses, return an empty dictionary
         if (responses is null || responses.Count == 0)
         {
             return new Dictionary<string, KestrunRouteResponseSchema>(StringComparer.OrdinalIgnoreCase);
         }
 
+        // Convert each response status code to a KestrunRouteResponseSchema
         return responses.ToDictionary(
             static entry => entry.Key,
             static entry => new KestrunRouteResponseSchema
@@ -201,7 +203,7 @@ public sealed class KestrunRouteInspector : IKestrunRouteInspector
                     static item => item.Key,
                     static item => ToJsonNode(item.Value.Schema),
                     StringComparer.OrdinalIgnoreCase)
-                    ?? new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase)
+                    ?? [with(StringComparer.OrdinalIgnoreCase)]
             },
             StringComparer.OrdinalIgnoreCase);
     }
@@ -318,16 +320,19 @@ public sealed class KestrunRuntimeInspector : IKestrunRuntimeInspector
     /// <returns>A runtime status label.</returns>
     private static string ResolveStatus(KestrunHost host)
     {
+        // Determine the runtime status based on the host's state
         if (host.IsRunning)
         {
             return "running";
         }
 
+        // Determine the runtime status based on the host's state
         if (host.IsConfigured)
         {
             return "configured";
         }
 
+        // If the host is neither running nor configured, it is considered defined
         return "defined";
     }
 
@@ -405,11 +410,13 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
         }
 
         var acceptValidation = ValidateAccept(route, input);
+        // If the route has OpenAPI annotations, validate the Accept header.
         if (acceptValidation is not null)
         {
             return acceptValidation;
         }
 
+        // If we reach this point, the request is valid.
         return new KestrunRequestValidationResult
         {
             IsValid = true,
@@ -434,19 +441,16 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
 
         var headers = NormalizeHeaders(input.Headers);
         var hasBody = HasBody(input.Body);
-        headers.TryGetValue(HeaderNames.ContentType, out var contentType);
+        _ = headers.TryGetValue(HeaderNames.ContentType, out var contentType);
 
         if (string.IsNullOrWhiteSpace(contentType))
         {
-            if (!hasBody)
-            {
-                return null;
-            }
-
-            return Failure(415, $"Content-Type is required. Supported types: {string.Join(", ", route.AllowedRequestContentTypes)}.", "missing_content_type");
+            return !hasBody
+                ? null
+                : Failure(415, $"Content-Type is required. Supported types: {string.Join(", ", route.AllowedRequestContentTypes)}.", "missing_content_type");
         }
 
-        if (!Microsoft.Net.Http.Headers.MediaTypeHeaderValue.TryParse(contentType, out var mediaType))
+        if (!MediaTypeHeaderValue.TryParse(contentType, out var mediaType))
         {
             return Failure(400, $"Content-Type header '{contentType}' is malformed.", "invalid_content_type");
         }
@@ -520,8 +524,8 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
         }
 
         var template = TemplateParser.Parse(pattern);
-        var matcher = new TemplateMatcher(template, new RouteValueDictionary());
-        return matcher.TryMatch(requestPath, new RouteValueDictionary());
+        var matcher = new TemplateMatcher(template, []);
+        return matcher.TryMatch(requestPath, []);
     }
 
     /// <summary>
@@ -531,12 +535,9 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
     /// <returns>The likely successful response content types.</returns>
     internal static IReadOnlyList<ContentTypeWithSchema> ResolveResponseContentTypes(MapRouteOptions route)
     {
-        if (TryGetResponseContentTypes(route.DefaultResponseContentType, StatusCodes.Status200OK, out var values) && values is not null)
-        {
-            return values as IReadOnlyList<ContentTypeWithSchema> ?? [.. values];
-        }
-
-        return [];
+        return TryGetResponseContentTypes(route.DefaultResponseContentType, StatusCodes.Status200OK, out var values) && values is not null
+            ? values as IReadOnlyList<ContentTypeWithSchema> ?? [.. values]
+            : [];
     }
 
     /// <summary>
@@ -562,7 +563,7 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
     /// <returns>A normalized header dictionary.</returns>
     private static Dictionary<string, string> NormalizeHeaders(IDictionary<string, string>? headers)
         => headers is null
-            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            ? [with(StringComparer.OrdinalIgnoreCase)]
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
@@ -676,7 +677,7 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
             return supported[0];
         }
 
-        if (!Microsoft.Net.Http.Headers.MediaTypeHeaderValue.TryParseList([acceptHeader], out var accepts) || accepts.Count == 0)
+        if (!MediaTypeHeaderValue.TryParseList([acceptHeader], out var accepts) || accepts.Count == 0)
         {
             return supported[0];
         }
@@ -717,12 +718,14 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
     /// <returns>The selected content type entry.</returns>
     private static ContentTypeWithSchema SelectWhenAnySupported(string normalizedAccept, string defaultType)
     {
+        // If the Accept header is a wildcard, return the default type.
         if (string.Equals(normalizedAccept, "*/*", StringComparison.OrdinalIgnoreCase) ||
             normalizedAccept.EndsWith("/*", StringComparison.OrdinalIgnoreCase))
         {
             return new ContentTypeWithSchema(defaultType, null);
         }
 
+        // If the Accept header is not a wildcard, resolve a concrete media type.
         return new ContentTypeWithSchema(ResolveWriterMediaType(normalizedAccept, defaultType), null);
     }
 
@@ -781,6 +784,7 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
     private static string ResolveWriterMediaType(string normalizedAccept, string defaultType)
     {
         var canonical = MediaTypeHelper.Canonicalize(normalizedAccept);
+        // If the Accept header is a known canonical type, return it.
         if (string.Equals(canonical, "application/json", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(canonical, "application/xml", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(canonical, "application/yaml", StringComparison.OrdinalIgnoreCase))
@@ -788,12 +792,14 @@ public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspecto
             return canonical;
         }
 
+        // If the Accept header is a specific type, return it.
         if (string.Equals(normalizedAccept, "text/csv", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(normalizedAccept, "application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
         {
             return normalizedAccept;
         }
 
+        // If the Accept header is a text type, return text/plain.
         return normalizedAccept.StartsWith("text/", StringComparison.OrdinalIgnoreCase) ? "text/plain" : defaultType;
     }
 }
@@ -937,10 +943,10 @@ public sealed class KestrunRequestInvoker(
         var first = true;
         foreach (var pair in query)
         {
-            builder.Append(first ? '?' : '&');
-            builder.Append(WebUtility.UrlEncode(pair.Key));
-            builder.Append('=');
-            builder.Append(WebUtility.UrlEncode(pair.Value));
+            _ = builder.Append(first ? '?' : '&').
+            Append(WebUtility.UrlEncode(pair.Key)).
+            Append('=').
+            Append(WebUtility.UrlEncode(pair.Value));
             first = false;
         }
 
@@ -1021,11 +1027,13 @@ public sealed class KestrunRequestInvoker(
     /// <returns>True when the path is allowlisted.</returns>
     private bool IsPathAllowed(string path)
     {
+        // If no allowed path patterns are configured, deny all paths.
         if (_options.AllowedPathPatterns.Count == 0)
         {
             return false;
         }
 
+        // Check if the path matches any of the allowed patterns.
         return _options.AllowedPathPatterns.Any(pattern =>
             string.Equals(pattern, "*", StringComparison.Ordinal) ||
             GlobMatches(pattern, path));

--- a/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
+++ b/src/CSharp/Kestrun/Mcp/KestrunMcpServices.cs
@@ -1,0 +1,1081 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Kestrun.Hosting;
+using Kestrun.Hosting.Options;
+using Kestrun.OpenApi;
+using Kestrun.Runtime;
+using Kestrun.Utilities;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Net.Http.Headers;
+using Microsoft.OpenApi;
+
+namespace Kestrun.Mcp;
+
+/// <summary>
+/// Default route inspector implementation backed by <see cref="KestrunHost"/>.
+/// </summary>
+public sealed class KestrunRouteInspector : IKestrunRouteInspector
+{
+    internal static readonly IEqualityComparer<MapRouteOptions> RouteReferenceComparer = new MapRouteOptionsReferenceComparer();
+
+    /// <inheritdoc />
+    public IReadOnlyList<KestrunRouteSummary> ListRoutes(KestrunHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        return [.. host.RegisteredRoutes.Values
+            .Distinct(RouteReferenceComparer)
+            .Select(CreateSummary)
+            .OrderBy(static route => route.Pattern, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <inheritdoc />
+    public KestrunRouteDetail GetRoute(KestrunHost host, string? pattern = null, string? operationId = null)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        var matches = FindMatchingRoutes(host, pattern, operationId);
+        if (matches.Count == 0)
+        {
+            return new KestrunRouteDetail
+            {
+                Route = EmptyRoute(pattern, operationId),
+                RequestSchemas = new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase),
+                Responses = new Dictionary<string, KestrunRouteResponseSchema>(StringComparer.OrdinalIgnoreCase),
+                Error = new KestrunMcpError(
+                    "route_not_found",
+                    "No route matched the requested pattern/operation id.",
+                    new Dictionary<string, object?> { ["pattern"] = pattern, ["operationId"] = operationId })
+            };
+        }
+
+        if (matches.Count > 1)
+        {
+            return new KestrunRouteDetail
+            {
+                Route = CreateSummary(matches[0]),
+                RequestSchemas = new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase),
+                Responses = new Dictionary<string, KestrunRouteResponseSchema>(StringComparer.OrdinalIgnoreCase),
+                Error = new KestrunMcpError(
+                    "ambiguous_route",
+                    "More than one route matched the request. Refine the selection with a unique pattern or operation id.",
+                    new Dictionary<string, object?>
+                    {
+                        ["pattern"] = pattern,
+                        ["operationId"] = operationId,
+                        ["matches"] = matches.Select(CreateSummary).ToArray()
+                    })
+            };
+        }
+
+        var route = matches[0];
+        return new KestrunRouteDetail
+        {
+            Route = CreateSummary(route),
+            RequestSchemas = BuildRequestSchemas(route),
+            Responses = BuildResponseSchemas(route),
+            Error = null
+        };
+    }
+
+    /// <summary>
+    /// Finds matching routes by pattern and/or operation id.
+    /// </summary>
+    /// <param name="host">The Kestrun host.</param>
+    /// <param name="pattern">Optional route pattern.</param>
+    /// <param name="operationId">Optional operation id.</param>
+    /// <returns>The matching route options.</returns>
+    private static List<MapRouteOptions> FindMatchingRoutes(KestrunHost host, string? pattern, string? operationId)
+    {
+        var routes = host.RegisteredRoutes.Values.Distinct(RouteReferenceComparer);
+
+        if (!string.IsNullOrWhiteSpace(pattern))
+        {
+            routes = routes.Where(route => string.Equals(route.Pattern, pattern, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(operationId))
+        {
+            routes = routes.Where(route => route.OpenAPI.Values.Any(meta => string.Equals(meta.OperationId, operationId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return [.. routes];
+    }
+
+    /// <summary>
+    /// Builds a summarized route descriptor.
+    /// </summary>
+    /// <param name="route">The route options.</param>
+    /// <returns>The route summary.</returns>
+    internal static KestrunRouteSummary CreateSummary(MapRouteOptions route)
+    {
+        var metadata = route.OpenAPI.Values.FirstOrDefault();
+        var responses = route.DefaultResponseContentType?
+            .SelectMany(static entry => entry.Value.Select(value => value.ContentType))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+
+        return new KestrunRouteSummary
+        {
+            Pattern = route.Pattern ?? "/",
+            Verbs = [.. route.HttpVerbs.Select(static verb => verb.ToMethodString())],
+            Tags = [.. metadata?.Tags ?? []],
+            Summary = metadata?.Summary,
+            Description = metadata?.Description,
+            RequestContentTypes = [.. route.AllowedRequestContentTypes.Distinct(StringComparer.OrdinalIgnoreCase)],
+            ResponseContentTypes = responses,
+            HandlerName = route.HandlerName,
+            HandlerLanguage = route.ScriptCode.Language.ToString(),
+            OperationId = metadata?.OperationId
+        };
+    }
+
+    /// <summary>
+    /// Creates an empty route summary used in lookup failures.
+    /// </summary>
+    /// <param name="pattern">Requested pattern.</param>
+    /// <param name="operationId">Requested operation id.</param>
+    /// <returns>An empty route summary.</returns>
+    private static KestrunRouteSummary EmptyRoute(string? pattern, string? operationId)
+    {
+        return new KestrunRouteSummary
+        {
+            Pattern = pattern ?? "/",
+            Verbs = [],
+            Tags = [],
+            Summary = null,
+            Description = null,
+            RequestContentTypes = [],
+            ResponseContentTypes = [],
+            HandlerName = null,
+            HandlerLanguage = null,
+            OperationId = operationId
+        };
+    }
+
+    /// <summary>
+    /// Builds request schema payloads from OpenAPI metadata.
+    /// </summary>
+    /// <param name="route">The route options.</param>
+    /// <returns>Request schemas keyed by content type.</returns>
+    private static IReadOnlyDictionary<string, JsonNode?> BuildRequestSchemas(MapRouteOptions route)
+    {
+        var metadata = route.OpenAPI.Values.FirstOrDefault();
+        var requestBody = metadata?.RequestBody;
+        if (requestBody?.Content is null || requestBody.Content.Count == 0)
+        {
+            return new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return requestBody.Content.ToDictionary(
+            static entry => entry.Key,
+            static entry => ToJsonNode(entry.Value.Schema),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Builds response schema payloads from OpenAPI metadata.
+    /// </summary>
+    /// <param name="route">The route options.</param>
+    /// <returns>Responses keyed by status code.</returns>
+    private static IReadOnlyDictionary<string, KestrunRouteResponseSchema> BuildResponseSchemas(MapRouteOptions route)
+    {
+        var metadata = route.OpenAPI.Values.FirstOrDefault();
+        var responses = metadata?.Responses;
+        if (responses is null || responses.Count == 0)
+        {
+            return new Dictionary<string, KestrunRouteResponseSchema>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return responses.ToDictionary(
+            static entry => entry.Key,
+            static entry => new KestrunRouteResponseSchema
+            {
+                Description = entry.Value.Description,
+                Content = entry.Value.Content?.ToDictionary(
+                    static item => item.Key,
+                    static item => ToJsonNode(item.Value.Schema),
+                    StringComparer.OrdinalIgnoreCase)
+                    ?? new Dictionary<string, JsonNode?>(StringComparer.OrdinalIgnoreCase)
+            },
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Converts an OpenAPI element into JSON.
+    /// </summary>
+    /// <param name="openApiElement">The OpenAPI element to serialize.</param>
+    /// <returns>A JSON node representation when available.</returns>
+    private static JsonNode? ToJsonNode(IOpenApiSerializable? openApiElement)
+    {
+        if (openApiElement is null)
+        {
+            return null;
+        }
+
+        using var writer = new StringWriter();
+        var jsonWriter = new OpenApiJsonWriter(writer);
+        openApiElement.SerializeAsV31(jsonWriter);
+        return JsonNode.Parse(writer.ToString());
+    }
+
+    /// <summary>
+    /// Reference-equality comparer for route options.
+    /// </summary>
+    private sealed class MapRouteOptionsReferenceComparer : IEqualityComparer<MapRouteOptions>
+    {
+        /// <inheritdoc />
+        public bool Equals(MapRouteOptions? x, MapRouteOptions? y) => ReferenceEquals(x, y);
+
+        /// <inheritdoc />
+        public int GetHashCode(MapRouteOptions obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}
+
+/// <summary>
+/// Default OpenAPI provider implementation backed by <see cref="KestrunHost"/>.
+/// </summary>
+public sealed class KestrunOpenApiProvider : IKestrunOpenApiProvider
+{
+    /// <inheritdoc />
+    public KestrunOpenApiDocumentResult GetOpenApi(KestrunHost host, string? documentId = null, string? version = null)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        var docId = string.IsNullOrWhiteSpace(documentId)
+            ? host.DefaultOpenApiDocumentDescriptor?.DocumentId ?? OpenApiDocDescriptor.DefaultDocumentationId
+            : documentId;
+
+        var descriptor = host.GetOrCreateOpenApiDocument(docId);
+
+        if (!descriptor.HasBeenGenerated)
+        {
+            descriptor.GenerateDoc();
+        }
+
+        OpenApiSpecVersion specVersion;
+        try
+        {
+            specVersion = string.IsNullOrWhiteSpace(version)
+                ? OpenApiSpecVersion.OpenApi3_1
+                : version.ParseOpenApiSpecVersion();
+        }
+        catch (ArgumentException ex)
+        {
+            return new KestrunOpenApiDocumentResult
+            {
+                DocumentId = docId,
+                Version = version ?? OpenApiSpecVersion.OpenApi3_1.ToVersionString(),
+                Error = new KestrunMcpError(
+                    "unsupported_openapi_version",
+                    ex.Message,
+                    new Dictionary<string, object?> { ["version"] = version })
+            };
+        }
+
+        return new KestrunOpenApiDocumentResult
+        {
+            DocumentId = docId,
+            Version = specVersion.ToVersionString(),
+            Document = JsonNode.Parse(descriptor.ToJson(specVersion))
+        };
+    }
+}
+
+/// <summary>
+/// Default runtime inspector implementation backed by <see cref="KestrunHost"/>.
+/// </summary>
+public sealed class KestrunRuntimeInspector : IKestrunRuntimeInspector
+{
+    /// <inheritdoc />
+    public KestrunRuntimeInspectionResult Inspect(KestrunHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        return new KestrunRuntimeInspectionResult
+        {
+            ApplicationName = host.ApplicationName,
+            Status = ResolveStatus(host),
+            Environment = EnvironmentHelper.Name,
+            StartTimeUtc = host.Runtime.StartTime,
+            StopTimeUtc = host.Runtime.StopTime,
+            Uptime = host.Runtime.Uptime,
+            Listeners = [.. host.Options.Listeners.Select(CreateListener)],
+            RouteCount = host.RegisteredRoutes.Count,
+            Configuration = BuildSafeConfiguration(host)
+        };
+    }
+
+    /// <summary>
+    /// Resolves the runtime status label.
+    /// </summary>
+    /// <param name="host">The Kestrun host.</param>
+    /// <returns>A runtime status label.</returns>
+    private static string ResolveStatus(KestrunHost host)
+    {
+        if (host.IsRunning)
+        {
+            return "running";
+        }
+
+        if (host.IsConfigured)
+        {
+            return "configured";
+        }
+
+        return "defined";
+    }
+
+    /// <summary>
+    /// Builds safe listener metadata.
+    /// </summary>
+    /// <param name="listener">The listener options.</param>
+    /// <returns>The runtime listener record.</returns>
+    private static KestrunRuntimeListener CreateListener(ListenerOptions listener)
+    {
+        return new KestrunRuntimeListener
+        {
+            Url = listener.ToString(),
+            Protocols = listener.Protocols.ToString(),
+            UseHttps = listener.UseHttps
+        };
+    }
+
+    /// <summary>
+    /// Builds a safe runtime configuration snapshot.
+    /// </summary>
+    /// <param name="host">The Kestrun host.</param>
+    /// <returns>A safe configuration snapshot.</returns>
+    private static IReadOnlyDictionary<string, object?> BuildSafeConfiguration(KestrunHost host)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["maxRunspaces"] = host.Options.MaxRunspaces,
+            ["minRunspaces"] = host.Options.MinRunspaces,
+            ["maxSchedulerRunspaces"] = host.Options.MaxSchedulerRunspaces,
+            ["currentUrls"] = host.CurrentUrls,
+            ["defaultResponseContentTypes"] = host.Options.DefaultResponseMediaType,
+            ["defaultApiResponseContentTypes"] = host.Options.DefaultApiResponseMediaType,
+            ["namedPipes"] = host.Options.NamedPipeNames,
+            ["unixSockets"] = host.Options.ListenUnixSockets
+        };
+    }
+}
+
+/// <summary>
+/// Default request validation implementation backed by route metadata.
+/// </summary>
+public sealed class KestrunRequestValidator(IKestrunRouteInspector routeInspector) : IKestrunRequestValidator
+{
+    private readonly IKestrunRouteInspector _routeInspector = routeInspector ?? throw new ArgumentNullException(nameof(routeInspector));
+
+    /// <inheritdoc />
+    public KestrunRequestValidationResult Validate(KestrunHost host, KestrunRequestInput input)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(input);
+
+        var method = NormalizeMethod(input.Method);
+        var requestPath = NormalizePath(input.Path);
+        var matches = FindPathMatches(host, requestPath);
+        if (matches.Count == 0)
+        {
+            return Failure(404, "No registered route matches the requested path.", "route_not_found");
+        }
+
+        var route = matches.FirstOrDefault(candidate => candidate.HttpVerbs.Any(verb => string.Equals(verb.ToMethodString(), method, StringComparison.OrdinalIgnoreCase)));
+        if (route is null)
+        {
+            var allowedMethods = matches.SelectMany(static candidate => candidate.HttpVerbs).Select(static verb => verb.ToMethodString()).Distinct().ToArray();
+            return Failure(
+                404,
+                $"No route matched method '{method}' for path '{requestPath}'. Registered methods: {string.Join(", ", allowedMethods)}.",
+                "method_not_matched");
+        }
+
+        var contentTypeValidation = ValidateContentType(route, input);
+        if (contentTypeValidation is not null)
+        {
+            return contentTypeValidation;
+        }
+
+        var acceptValidation = ValidateAccept(route, input);
+        if (acceptValidation is not null)
+        {
+            return acceptValidation;
+        }
+
+        return new KestrunRequestValidationResult
+        {
+            IsValid = true,
+            StatusCode = 200,
+            Message = "The request matches a registered route and satisfies known content-type/accept constraints.",
+            Route = _routeInspector.GetRoute(host, route.Pattern).Route
+        };
+    }
+
+    /// <summary>
+    /// Validates request content type constraints.
+    /// </summary>
+    /// <param name="route">The selected route.</param>
+    /// <param name="input">The request input.</param>
+    /// <returns>A failure result when validation fails; otherwise null.</returns>
+    private KestrunRequestValidationResult? ValidateContentType(MapRouteOptions route, KestrunRequestInput input)
+    {
+        if (route.AllowedRequestContentTypes.Count == 0)
+        {
+            return null;
+        }
+
+        var headers = NormalizeHeaders(input.Headers);
+        var hasBody = HasBody(input.Body);
+        headers.TryGetValue(HeaderNames.ContentType, out var contentType);
+
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            if (!hasBody)
+            {
+                return null;
+            }
+
+            return Failure(415, $"Content-Type is required. Supported types: {string.Join(", ", route.AllowedRequestContentTypes)}.", "missing_content_type");
+        }
+
+        if (!Microsoft.Net.Http.Headers.MediaTypeHeaderValue.TryParse(contentType, out var mediaType))
+        {
+            return Failure(400, $"Content-Type header '{contentType}' is malformed.", "invalid_content_type");
+        }
+
+        var raw = mediaType.MediaType.ToString();
+        var canonical = MediaTypeHelper.Canonicalize(raw);
+        var allowed = route.AllowedRequestContentTypes.Any(candidate =>
+            string.Equals(candidate, raw, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(MediaTypeHelper.Canonicalize(candidate), canonical, StringComparison.OrdinalIgnoreCase));
+
+        return allowed
+            ? null
+            : Failure(415, $"Content-Type '{raw}' is not allowed. Supported types: {string.Join(", ", route.AllowedRequestContentTypes)}.", "unsupported_media_type");
+    }
+
+    /// <summary>
+    /// Validates Accept-header constraints for OpenAPI-aware routes.
+    /// </summary>
+    /// <param name="route">The selected route.</param>
+    /// <param name="input">The request input.</param>
+    /// <returns>A failure result when validation fails; otherwise null.</returns>
+    private static KestrunRequestValidationResult? ValidateAccept(MapRouteOptions route, KestrunRequestInput input)
+    {
+        if (!route.IsOpenApiAnnotatedFunctionRoute)
+        {
+            return null;
+        }
+
+        var headers = NormalizeHeaders(input.Headers);
+        if (!headers.TryGetValue(HeaderNames.Accept, out var acceptHeader) || string.IsNullOrWhiteSpace(acceptHeader))
+        {
+            return null;
+        }
+
+        var supported = ResolveResponseContentTypes(route);
+        if (supported.Count == 0)
+        {
+            return null;
+        }
+
+        var selected = SelectResponseMediaType(acceptHeader, supported, supported[0].ContentType);
+        return selected is not null
+            ? null
+            : Failure(406, $"Accept header '{acceptHeader}' is not compatible with the route response types: {string.Join(", ", supported.Select(static value => value.ContentType))}.", "not_acceptable");
+    }
+
+    /// <summary>
+    /// Finds registered routes whose template matches the provided path.
+    /// </summary>
+    /// <param name="host">The Kestrun host.</param>
+    /// <param name="requestPath">The request path.</param>
+    /// <returns>The matching routes.</returns>
+    private static List<MapRouteOptions> FindPathMatches(KestrunHost host, string requestPath)
+    {
+        return [.. host.RegisteredRoutes.Values
+            .Distinct(KestrunRouteInspector.RouteReferenceComparer)
+            .Where(route => RoutePatternMatches(route.Pattern, requestPath))];
+    }
+
+    /// <summary>
+    /// Determines whether a route pattern matches the supplied request path.
+    /// </summary>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="requestPath">The request path.</param>
+    /// <returns>True when the path matches the route template.</returns>
+    private static bool RoutePatternMatches(string? pattern, string requestPath)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return false;
+        }
+
+        var template = TemplateParser.Parse(pattern);
+        var matcher = new TemplateMatcher(template, new RouteValueDictionary());
+        return matcher.TryMatch(requestPath, new RouteValueDictionary());
+    }
+
+    /// <summary>
+    /// Resolves likely response content types for validation.
+    /// </summary>
+    /// <param name="route">The route options.</param>
+    /// <returns>The likely successful response content types.</returns>
+    internal static IReadOnlyList<ContentTypeWithSchema> ResolveResponseContentTypes(MapRouteOptions route)
+    {
+        if (TryGetResponseContentTypes(route.DefaultResponseContentType, StatusCodes.Status200OK, out var values) && values is not null)
+        {
+            return values as IReadOnlyList<ContentTypeWithSchema> ?? [.. values];
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Normalizes request method values.
+    /// </summary>
+    /// <param name="method">The incoming method.</param>
+    /// <returns>A normalized method.</returns>
+    private static string NormalizeMethod(string? method)
+        => string.IsNullOrWhiteSpace(method) ? "GET" : method.Trim().ToUpperInvariant();
+
+    /// <summary>
+    /// Normalizes request path values.
+    /// </summary>
+    /// <param name="path">The incoming path.</param>
+    /// <returns>A normalized path.</returns>
+    private static string NormalizePath(string? path)
+        => string.IsNullOrWhiteSpace(path) ? "/" : path.StartsWith('/') ? path : "/" + path;
+
+    /// <summary>
+    /// Normalizes headers into a case-insensitive dictionary.
+    /// </summary>
+    /// <param name="headers">The incoming headers.</param>
+    /// <returns>A normalized header dictionary.</returns>
+    private static Dictionary<string, string> NormalizeHeaders(IDictionary<string, string>? headers)
+        => headers is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether a request body is present.
+    /// </summary>
+    /// <param name="body">The request body.</param>
+    /// <returns>True when a body is present.</returns>
+    private static bool HasBody(object? body)
+    {
+        return body switch
+        {
+            null => false,
+            string text => !string.IsNullOrEmpty(text),
+            JsonNode => true,
+            _ => true
+        };
+    }
+
+    /// <summary>
+    /// Creates a standardized failure payload.
+    /// </summary>
+    /// <param name="statusCode">The likely status code.</param>
+    /// <param name="message">The validation message.</param>
+    /// <param name="code">The stable error code.</param>
+    /// <returns>A failure result.</returns>
+    private static KestrunRequestValidationResult Failure(int statusCode, string message, string code)
+    {
+        return new KestrunRequestValidationResult
+        {
+            IsValid = false,
+            StatusCode = statusCode,
+            Message = message,
+            Error = new KestrunMcpError(code, message)
+        };
+    }
+
+    /// <summary>
+    /// Resolves response content types for a status code using exact, range, then default lookup.
+    /// </summary>
+    /// <param name="contentTypes">Configured content type mappings.</param>
+    /// <param name="statusCode">The status code to resolve.</param>
+    /// <param name="values">Resolved content types when available.</param>
+    /// <returns>True when a mapping exists.</returns>
+    internal static bool TryGetResponseContentTypes(
+        IDictionary<string, ICollection<ContentTypeWithSchema>>? contentTypes,
+        int statusCode,
+        out ICollection<ContentTypeWithSchema>? values)
+    {
+        values = null;
+        if (contentTypes is null || contentTypes.Count == 0)
+        {
+            return false;
+        }
+
+        var statusKey = statusCode.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (TryGetValueIgnoreCase(contentTypes, statusKey, out values))
+        {
+            return true;
+        }
+
+        if (statusCode is >= 100 and <= 599)
+        {
+            var rangeKey = $"{statusCode / 100}XX";
+            if (TryGetValueIgnoreCase(contentTypes, rangeKey, out values))
+            {
+                return true;
+            }
+        }
+
+        return TryGetValueIgnoreCase(contentTypes, "default", out values);
+    }
+
+    /// <summary>
+    /// Performs a case-insensitive dictionary lookup.
+    /// </summary>
+    /// <param name="dictionary">The source dictionary.</param>
+    /// <param name="key">The requested key.</param>
+    /// <param name="value">The resolved value when present.</param>
+    /// <returns>True when a value exists.</returns>
+    internal static bool TryGetValueIgnoreCase<TValue>(IDictionary<string, TValue> dictionary, string key, out TValue? value)
+    {
+        foreach (var entry in dictionary)
+        {
+            if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = entry.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Selects the most appropriate response media type for a supplied Accept header.
+    /// </summary>
+    /// <param name="acceptHeader">The incoming Accept header value.</param>
+    /// <param name="supported">Supported response media types.</param>
+    /// <param name="defaultType">Fallback type when <c>*/*</c> is configured.</param>
+    /// <returns>The selected content type or null when no match exists.</returns>
+    internal static ContentTypeWithSchema? SelectResponseMediaType(string? acceptHeader, IReadOnlyList<ContentTypeWithSchema> supported, string defaultType)
+    {
+        if (supported.Count == 0)
+        {
+            return new ContentTypeWithSchema(defaultType, null);
+        }
+
+        if (string.IsNullOrWhiteSpace(acceptHeader))
+        {
+            return supported[0];
+        }
+
+        if (!Microsoft.Net.Http.Headers.MediaTypeHeaderValue.TryParseList([acceptHeader], out var accepts) || accepts.Count == 0)
+        {
+            return supported[0];
+        }
+
+        var supportsAnyMediaType = supported.Any(static value => string.Equals(MediaTypeHelper.Normalize(value.ContentType), "*/*", StringComparison.OrdinalIgnoreCase));
+        var normalizedSupported = supported.Select(static value => MediaTypeHelper.Normalize(value.ContentType)).ToArray();
+        var canonicalSupported = supported.Select(static value => MediaTypeHelper.Canonicalize(value.ContentType)).ToArray();
+
+        foreach (var candidate in accepts.OrderByDescending(static value => value.Quality ?? 1.0))
+        {
+            var accept = candidate.MediaType.Value;
+            if (accept is null)
+            {
+                continue;
+            }
+
+            var normalizedAccept = MediaTypeHelper.Normalize(accept);
+            if (supportsAnyMediaType)
+            {
+                return SelectWhenAnySupported(normalizedAccept, defaultType);
+            }
+
+            var selected = SelectConfiguredMediaType(normalizedAccept, supported, normalizedSupported, canonicalSupported);
+            if (selected is not null)
+            {
+                return selected;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Selects a media type when the route supports any response media type.
+    /// </summary>
+    /// <param name="normalizedAccept">The normalized Accept header value.</param>
+    /// <param name="defaultType">The fallback response type.</param>
+    /// <returns>The selected content type entry.</returns>
+    private static ContentTypeWithSchema SelectWhenAnySupported(string normalizedAccept, string defaultType)
+    {
+        if (string.Equals(normalizedAccept, "*/*", StringComparison.OrdinalIgnoreCase) ||
+            normalizedAccept.EndsWith("/*", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ContentTypeWithSchema(defaultType, null);
+        }
+
+        return new ContentTypeWithSchema(ResolveWriterMediaType(normalizedAccept, defaultType), null);
+    }
+
+    /// <summary>
+    /// Selects a configured media type for an Accept header.
+    /// </summary>
+    /// <param name="normalizedAccept">The normalized Accept header value.</param>
+    /// <param name="supported">Supported media types.</param>
+    /// <param name="normalizedSupported">Normalized supported media types.</param>
+    /// <param name="canonicalSupported">Canonical supported media types.</param>
+    /// <returns>The selected media type entry when available.</returns>
+    private static ContentTypeWithSchema? SelectConfiguredMediaType(
+        string normalizedAccept,
+        IReadOnlyList<ContentTypeWithSchema> supported,
+        IReadOnlyList<string> normalizedSupported,
+        IReadOnlyList<string> canonicalSupported)
+    {
+        if (string.Equals(normalizedAccept, "*/*", StringComparison.OrdinalIgnoreCase))
+        {
+            return supported[0];
+        }
+
+        if (normalizedAccept.EndsWith("/*", StringComparison.OrdinalIgnoreCase))
+        {
+            var prefix = normalizedAccept[..^1];
+            for (var i = 0; i < supported.Count; i++)
+            {
+                if (normalizedSupported[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return supported[i];
+                }
+            }
+
+            return null;
+        }
+
+        var canonicalAccept = MediaTypeHelper.Canonicalize(normalizedAccept);
+        for (var i = 0; i < supported.Count; i++)
+        {
+            if (string.Equals(normalizedSupported[i], normalizedAccept, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(canonicalSupported[i], canonicalAccept, StringComparison.OrdinalIgnoreCase))
+            {
+                return supported[i];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a concrete writer media type for wildcard routes.
+    /// </summary>
+    /// <param name="normalizedAccept">The normalized Accept header value.</param>
+    /// <param name="defaultType">The fallback type.</param>
+    /// <returns>A concrete writer media type.</returns>
+    private static string ResolveWriterMediaType(string normalizedAccept, string defaultType)
+    {
+        var canonical = MediaTypeHelper.Canonicalize(normalizedAccept);
+        if (string.Equals(canonical, "application/json", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(canonical, "application/xml", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(canonical, "application/yaml", StringComparison.OrdinalIgnoreCase))
+        {
+            return canonical;
+        }
+
+        if (string.Equals(normalizedAccept, "text/csv", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalizedAccept, "application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+        {
+            return normalizedAccept;
+        }
+
+        return normalizedAccept.StartsWith("text/", StringComparison.OrdinalIgnoreCase) ? "text/plain" : defaultType;
+    }
+}
+
+/// <summary>
+/// Default route invoker implementation that uses the live HTTP pipeline.
+/// </summary>
+public sealed class KestrunRequestInvoker(
+    IKestrunRequestValidator validator,
+    KestrunRequestInvokerOptions options) : IKestrunRequestInvoker
+{
+    private readonly IKestrunRequestValidator _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+    private readonly KestrunRequestInvokerOptions _options = options ?? throw new ArgumentNullException(nameof(options));
+
+    /// <inheritdoc />
+    public async Task<KestrunRouteInvokeResult> InvokeAsync(KestrunHost host, KestrunRequestInput input, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(input);
+
+        var path = NormalizePath(input.Path);
+        if (!_options.EnableInvocation)
+        {
+            return Failure(403, "Route invocation is disabled for this MCP server.", "invoke_disabled");
+        }
+
+        if (!IsPathAllowed(path))
+        {
+            return Failure(403, $"Route '{path}' is not allowlisted for invocation.", "invoke_not_allowlisted");
+        }
+
+        var validation = _validator.Validate(host, input);
+        if (!validation.IsValid)
+        {
+            return new KestrunRouteInvokeResult
+            {
+                StatusCode = validation.StatusCode,
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                Error = validation.Error
+            };
+        }
+
+        var baseUri = ResolveBaseUri(host);
+        if (baseUri is null)
+        {
+            return Failure(503, "The Kestrun host is not running on a known listener URL.", "runtime_not_available");
+        }
+
+        try
+        {
+            using var httpClient = new HttpClient { BaseAddress = baseUri };
+            using var request = BuildRequestMessage(input);
+            using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var contentType = response.Content.Headers.ContentType?.ToString();
+            var body = response.Content is null ? null : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            return new KestrunRouteInvokeResult
+            {
+                StatusCode = (int)response.StatusCode,
+                ContentType = contentType,
+                Headers = RedactHeaders(response),
+                Body = body
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Failure(500, $"Route invocation failed: {ex.Message}", "invoke_failed");
+        }
+    }
+
+    /// <summary>
+    /// Builds an HTTP request message from the supplied invocation input.
+    /// </summary>
+    /// <param name="input">The invocation input.</param>
+    /// <returns>The request message.</returns>
+    private static HttpRequestMessage BuildRequestMessage(KestrunRequestInput input)
+    {
+        var uri = BuildRelativeUri(input.Path, input.Query);
+        var request = new HttpRequestMessage(new HttpMethod(string.IsNullOrWhiteSpace(input.Method) ? "GET" : input.Method), uri);
+        var headers = input.Headers ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var contentType = headers.TryGetValue(HeaderNames.ContentType, out var value) ? value : null;
+
+        foreach (var header in headers)
+        {
+            if (string.Equals(header.Key, HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                request.Content ??= new StringContent(string.Empty, Encoding.UTF8);
+                _ = request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        if (input.Body is not null)
+        {
+            request.Content = CreateContent(input.Body, contentType);
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Creates HTTP content for the invocation request.
+    /// </summary>
+    /// <param name="body">The request body.</param>
+    /// <param name="contentType">The request content type.</param>
+    /// <returns>The HTTP content.</returns>
+    private static HttpContent CreateContent(object body, string? contentType)
+    {
+        if (body is string text)
+        {
+            var mediaType = string.IsNullOrWhiteSpace(contentType) ? "text/plain" : contentType;
+            return new StringContent(text, Encoding.UTF8, mediaType);
+        }
+
+        var json = JsonSerializer.Serialize(body);
+        return new StringContent(json, Encoding.UTF8, string.IsNullOrWhiteSpace(contentType) ? "application/json" : contentType);
+    }
+
+    /// <summary>
+    /// Builds a relative request URI from path and query values.
+    /// </summary>
+    /// <param name="path">The route path.</param>
+    /// <param name="query">Optional query values.</param>
+    /// <returns>The request URI.</returns>
+    private static string BuildRelativeUri(string? path, IDictionary<string, string>? query)
+    {
+        var builder = new StringBuilder(NormalizePath(path));
+        if (query is null || query.Count == 0)
+        {
+            return builder.ToString();
+        }
+
+        var first = true;
+        foreach (var pair in query)
+        {
+            builder.Append(first ? '?' : '&');
+            builder.Append(WebUtility.UrlEncode(pair.Key));
+            builder.Append('=');
+            builder.Append(WebUtility.UrlEncode(pair.Value));
+            first = false;
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Resolves the first known loopback/base URL for the host.
+    /// </summary>
+    /// <param name="host">The running host.</param>
+    /// <returns>The resolved base URI when available.</returns>
+    private static Uri? ResolveBaseUri(KestrunHost host)
+    {
+        foreach (var url in host.CurrentUrls)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                return NormalizeLoopbackUri(uri);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Rewrites wildcard listener addresses to a loopback address suitable for local invocation.
+    /// </summary>
+    /// <param name="uri">The candidate listener URI.</param>
+    /// <returns>The rewritten URI when needed; otherwise the original URI.</returns>
+    private static Uri NormalizeLoopbackUri(Uri uri)
+    {
+        if (!string.Equals(uri.Host, "0.0.0.0", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Host, "::", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Host, "[::]", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Host, "*", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            Host = uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                ? "localhost"
+                : IPAddress.Loopback.ToString()
+        };
+
+        return builder.Uri;
+    }
+
+    /// <summary>
+    /// Redacts configured sensitive headers from response output.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <returns>A redacted header dictionary.</returns>
+    private IReadOnlyDictionary<string, string> RedactHeaders(HttpResponseMessage response)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in response.Headers)
+        {
+            headers[header.Key] = RedactIfSensitive(header.Key, string.Join(", ", header.Value));
+        }
+
+        if (response.Content is not null)
+        {
+            foreach (var header in response.Content.Headers)
+            {
+                headers[header.Key] = RedactIfSensitive(header.Key, string.Join(", ", header.Value));
+            }
+        }
+
+        return headers;
+    }
+
+    /// <summary>
+    /// Determines whether a path is allowlisted for invocation.
+    /// </summary>
+    /// <param name="path">The request path.</param>
+    /// <returns>True when the path is allowlisted.</returns>
+    private bool IsPathAllowed(string path)
+    {
+        if (_options.AllowedPathPatterns.Count == 0)
+        {
+            return false;
+        }
+
+        return _options.AllowedPathPatterns.Any(pattern =>
+            string.Equals(pattern, "*", StringComparison.Ordinal) ||
+            GlobMatches(pattern, path));
+    }
+
+    /// <summary>
+    /// Redacts sensitive header values.
+    /// </summary>
+    /// <param name="name">The header name.</param>
+    /// <param name="value">The original header value.</param>
+    /// <returns>The redacted or original value.</returns>
+    private string RedactIfSensitive(string name, string value)
+        => _options.RedactedHeaders.Contains(name) ? "[REDACTED]" : value;
+
+    /// <summary>
+    /// Matches a glob-style path pattern.
+    /// </summary>
+    /// <param name="pattern">The glob pattern.</param>
+    /// <param name="value">The candidate value.</param>
+    /// <returns>True when the value matches the pattern.</returns>
+    private static bool GlobMatches(string pattern, string value)
+    {
+        var regex = "^" + Regex.Escape(pattern)
+            .Replace("\\*", ".*", StringComparison.Ordinal)
+            .Replace("\\?", ".", StringComparison.Ordinal) + "$";
+        return Regex.IsMatch(value, regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    /// <summary>
+    /// Creates a standardized invocation failure payload.
+    /// </summary>
+    /// <param name="statusCode">The failure status code.</param>
+    /// <param name="message">The failure message.</param>
+    /// <param name="code">The stable error code.</param>
+    /// <returns>A failure result.</returns>
+    private static KestrunRouteInvokeResult Failure(int statusCode, string message, string code)
+    {
+        return new KestrunRouteInvokeResult
+        {
+            StatusCode = statusCode,
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Error = new KestrunMcpError(code, message)
+        };
+    }
+
+    /// <summary>
+    /// Normalizes request paths.
+    /// </summary>
+    /// <param name="path">The incoming path.</param>
+    /// <returns>A normalized path.</returns>
+    private static string NormalizePath(string? path)
+        => string.IsNullOrWhiteSpace(path) ? "/" : path.StartsWith('/') ? path : "/" + path;
+}

--- a/src/CSharp/Kestrun/OpenApi/OpenApiDocDescriptor_AnnotatedFunctions.cs
+++ b/src/CSharp/Kestrun/OpenApi/OpenApiDocDescriptor_AnnotatedFunctions.cs
@@ -1462,6 +1462,7 @@ public partial class OpenApiDocDescriptor
 
         // Set the script block or wrap for form options
         routeOptions.ScriptCode.ScriptBlock = sb;
+        routeOptions.HandlerName = func.Name;
         routeOptions.IsOpenApiAnnotatedFunctionRoute = true;
         routeOptions.DefaultResponseContentType ??= new Dictionary<string, ICollection<ContentTypeWithSchema>>(Host.Options.DefaultApiResponseMediaType);
         _ = Host.AddMapRoute(routeOptions);

--- a/tests/CSharp.Tests/Kestrun.Mcp.Tests/Kestrun.Mcp.Tests.csproj
+++ b/tests/CSharp.Tests/Kestrun.Mcp.Tests/Kestrun.Mcp.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../../src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj" />
+    </ItemGroup>
+</Project>

--- a/tests/CSharp.Tests/Kestrun.Mcp.Tests/Runtime/KestrunMcpRuntimeHostedServiceTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Mcp.Tests/Runtime/KestrunMcpRuntimeHostedServiceTests.cs
@@ -1,0 +1,98 @@
+using Kestrun.Mcp.ServerHost;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Kestrun.Mcp.Tests.Runtime;
+
+public sealed class KestrunMcpRuntimeHostedServiceTests : IDisposable
+{
+    private readonly List<string> _tempFiles = [];
+
+    public KestrunMcpRuntimeHostedServiceTests()
+    {
+        KestrunHostManager.DestroyAll();
+    }
+
+    public void Dispose()
+    {
+        KestrunHostManager.DestroyAll();
+
+        foreach (var path in _tempFiles)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_CompletesRuntimeWithError_WhenScriptDoesNotRegisterExpectedHost()
+    {
+        var runtime = new KestrunMcpRuntime();
+        var options = new KestrunMcpCommandLine(
+            ScriptPath: CreateScript("# Intentionally does not create a Kestrun host."),
+            ModuleManifestPath: ResolveModuleManifestPath(),
+            HostName: $"missing-host-{Guid.NewGuid():N}",
+            DiscoverPowerShellHome: true,
+            AllowInvokeRoute: false,
+            AllowedInvokePaths: []);
+
+        using var stoppingCts = new CancellationTokenSource();
+        var appLifetime = new Mock<IHostApplicationLifetime>(MockBehavior.Strict);
+        _ = appLifetime.SetupGet(static lifetime => lifetime.ApplicationStopping).Returns(stoppingCts.Token);
+        _ = appLifetime.Setup(static lifetime => lifetime.StopApplication());
+
+        var service = new KestrunScriptSessionHostedService(
+            options,
+            runtime,
+            NullLogger<KestrunScriptSessionHostedService>.Instance,
+            appLifetime.Object);
+
+        await service.StartAsync(CancellationToken.None);
+
+        using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runtime.WaitForHostAsync(waitCts.Token));
+
+        Assert.Contains("completed without registering", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(options.HostName!, exception.Message, StringComparison.Ordinal);
+        appLifetime.Verify(static lifetime => lifetime.StopApplication(), Times.Once);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Creates a temporary PowerShell script for hosted-service execution.
+    /// </summary>
+    /// <param name="contents">Script contents.</param>
+    /// <returns>The created script path.</returns>
+    private string CreateScript(string contents)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"kestrun-mcp-runtime-{Guid.NewGuid():N}.ps1");
+        File.WriteAllText(path, contents);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Resolves the local Kestrun module manifest path from the repository root.
+    /// </summary>
+    /// <returns>The absolute module manifest path.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the repository-local manifest cannot be found.</exception>
+    private static string ResolveModuleManifestPath()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "PowerShell", "Kestrun", "Kestrun.psd1");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new FileNotFoundException("Unable to locate src/PowerShell/Kestrun/Kestrun.psd1 from the test output directory.");
+    }
+}

--- a/tests/CSharp.Tests/Kestrun.Tests/Mcp/KestrunMcpIntegrationTests.cs
+++ b/tests/CSharp.Tests/Kestrun.Tests/Mcp/KestrunMcpIntegrationTests.cs
@@ -1,0 +1,386 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Kestrun.Hosting;
+using Kestrun.Hosting.Options;
+using Kestrun.Mcp;
+using Kestrun.OpenApi;
+using Kestrun.Scripting;
+using Kestrun.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OpenApi;
+using Serilog;
+using Xunit;
+
+namespace Kestrun.Tests.Mcp;
+
+[Collection("SharedStateSerial")]
+public sealed class KestrunMcpIntegrationTests
+{
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public void ListRoutes_ReturnsRegisteredRouteMetadata()
+    {
+        using var host = CreateHost("TestMcpRouteListing");
+        AddHelloRoute(host);
+        AddItemRoute(host);
+
+        var inspector = new KestrunRouteInspector();
+        var routes = inspector.ListRoutes(host);
+
+        Assert.Equal(2, routes.Count);
+
+        var hello = Assert.Single(routes, static route => route.Pattern == "/hello");
+        Assert.Equal(["GET"], hello.Verbs);
+        Assert.Equal("Get-Hello", hello.HandlerName);
+        Assert.Equal(nameof(ScriptLanguage.Native), hello.HandlerLanguage);
+
+        var items = Assert.Single(routes, static route => route.Pattern == "/items/{id}");
+        Assert.Equal(["POST"], items.Verbs);
+        Assert.Equal("createItem", items.OperationId);
+        Assert.Equal(["items"], items.Tags);
+        Assert.Contains("application/json", items.RequestContentTypes);
+        Assert.Contains("application/json", items.ResponseContentTypes);
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public void GetRoute_ReturnsOpenApiSchemas_ForOperationId()
+    {
+        using var host = CreateHost("TestMcpGetRoute");
+        AddItemRoute(host);
+
+        var inspector = new KestrunRouteInspector();
+        var detail = inspector.GetRoute(host, operationId: "createItem");
+
+        Assert.Null(detail.Error);
+        Assert.Equal("/items/{id}", detail.Route.Pattern);
+        Assert.True(detail.RequestSchemas.TryGetValue("application/json", out var requestSchema));
+        Assert.Equal("object", requestSchema?["type"]?.GetValue<string>());
+        Assert.Equal("string", requestSchema?["properties"]?["name"]?["type"]?.GetValue<string>());
+
+        Assert.True(detail.Responses.TryGetValue("200", out var response));
+        Assert.Equal("Created", response.Description);
+        Assert.Equal("integer", response.Content["application/json"]?["properties"]?["itemId"]?["type"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public void GetRoute_ReturnsStructuredError_WhenRouteMissing()
+    {
+        using var host = CreateHost("TestMcpMissingRoute");
+        AddHelloRoute(host);
+
+        var inspector = new KestrunRouteInspector();
+        var detail = inspector.GetRoute(host, pattern: "/missing");
+
+        var error = Assert.IsType<KestrunMcpError>(detail.Error);
+        Assert.Equal("route_not_found", error.Code);
+        Assert.Equal("/missing", detail.Route.Pattern);
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public void GetOpenApi_ReturnsStructuredJsonDocument()
+    {
+        using var host = CreateHost("TestMcpOpenApi");
+        AddItemRoute(host);
+
+        var provider = new KestrunOpenApiProvider();
+        var document = provider.GetOpenApi(host, version: "3.1");
+
+        Assert.Null(document.Error);
+        Assert.Equal("3.1.2", document.Version);
+        Assert.Equal("3.1.2", document.Document?["openapi"]?.GetValue<string>());
+        Assert.NotNull(document.Document?["paths"]?["/items/{id}"]?["post"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public void InspectRuntime_ReturnsSafeConfigurationSnapshot()
+    {
+        using var host = CreateHost("TestMcpRuntime");
+        AddHelloRoute(host);
+
+        var inspector = new KestrunRuntimeInspector();
+        var runtime = inspector.Inspect(host);
+        var validStatuses = new[] { "configured", "running" };
+
+        Assert.Contains(runtime.Status, validStatuses);
+        Assert.Equal(host.ApplicationName, runtime.ApplicationName);
+        Assert.Single(runtime.Listeners);
+        Assert.Equal(1, runtime.RouteCount);
+        Assert.True(runtime.Configuration.ContainsKey("currentUrls"));
+        Assert.True(runtime.Configuration.ContainsKey("maxRunspaces"));
+    }
+
+    [Theory]
+    [Trait("Category", "Mcp")]
+    [InlineData("/missing", "POST", null, 404, "route_not_found")]
+    [InlineData("/items/42", "POST", "text/plain", 415, "unsupported_media_type")]
+    [InlineData("/items/42", "POST", "application/json", 406, "not_acceptable", "text/plain")]
+    public void ValidateRequest_ReturnsExpectedOutcomes(
+        string path,
+        string method,
+        string? contentType,
+        int expectedStatusCode,
+        string expectedErrorCode,
+        string? accept = null)
+    {
+        using var host = CreateHost("TestMcpValidation");
+        AddItemRoute(host);
+
+        var validator = new KestrunRequestValidator(new KestrunRouteInspector());
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (contentType is not null)
+        {
+            headers["Content-Type"] = contentType;
+        }
+
+        if (accept is not null)
+        {
+            headers["Accept"] = accept;
+        }
+
+        var result = validator.Validate(
+            host,
+            new KestrunRequestInput
+            {
+                Method = method,
+                Path = path,
+                Headers = headers,
+                Body = new { name = "widget" }
+            });
+
+        Assert.False(result.IsValid);
+        Assert.Equal(expectedStatusCode, result.StatusCode);
+        Assert.Equal(expectedErrorCode, result.Error?.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public async Task InvokeRoute_ReturnsJsonResponse_ThroughFrameworkPipeline()
+    {
+        using var host = CreateHost("TestMcpInvoke");
+        AddItemRoute(host);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await host.StartAsync(cts.Token);
+        try
+        {
+            var invoker = CreateInvoker(enabled: true, "/items/*");
+            var result = await invoker.InvokeAsync(
+                host,
+                new KestrunRequestInput
+                {
+                    Method = "POST",
+                    Path = "/items/42",
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Content-Type"] = "application/json",
+                        ["Accept"] = "application/json"
+                    },
+                    Body = new { name = "widget" }
+                },
+                cts.Token);
+
+            Assert.Null(result.Error);
+            Assert.Equal(200, result.StatusCode);
+            Assert.Contains("application/json", result.ContentType, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(result.Body);
+            var payload = JsonNode.Parse(result.Body);
+            Assert.Equal(42, payload?["itemId"]?.GetValue<int>());
+            Assert.Equal("[REDACTED]", result.Headers["Set-Cookie"]);
+        }
+        finally
+        {
+            await host.StopAsync(cts.Token);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Mcp")]
+    public async Task InvokeRoute_ReturnsStructuredValidationErrors_ForInvalidRequests()
+    {
+        using var host = CreateHost("TestMcpInvokeValidation");
+        AddItemRoute(host);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await host.StartAsync(cts.Token);
+        try
+        {
+            var invoker = CreateInvoker(enabled: true, "/items/*");
+
+            var invalidContentType = await invoker.InvokeAsync(
+                host,
+                new KestrunRequestInput
+                {
+                    Method = "POST",
+                    Path = "/items/42",
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Content-Type"] = "text/plain"
+                    },
+                    Body = "widget"
+                },
+                cts.Token);
+
+            Assert.Equal(415, invalidContentType.StatusCode);
+            Assert.Equal("unsupported_media_type", invalidContentType.Error?.Code);
+
+            var invalidAccept = await invoker.InvokeAsync(
+                host,
+                new KestrunRequestInput
+                {
+                    Method = "POST",
+                    Path = "/items/42",
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Content-Type"] = "application/json",
+                        ["Accept"] = "text/plain"
+                    },
+                    Body = new { name = "widget" }
+                },
+                cts.Token);
+
+            Assert.Equal(406, invalidAccept.StatusCode);
+            Assert.Equal("not_acceptable", invalidAccept.Error?.Code);
+        }
+        finally
+        {
+            await host.StopAsync(cts.Token);
+        }
+    }
+
+    private static KestrunHost CreateHost(string name)
+    {
+        var logger = new LoggerConfiguration().CreateLogger();
+        var host = new KestrunHost(name, logger, AppContext.BaseDirectory);
+        host.ConfigureListener(0, IPAddress.Loopback, useConnectionLogging: false);
+        host.EnableConfiguration();
+        return host;
+    }
+
+    private static void AddHelloRoute(KestrunHost host)
+    {
+        var options = new MapRouteOptions
+        {
+            Pattern = "/hello",
+            HttpVerbs = [HttpVerb.Get],
+            HandlerName = "Get-Hello",
+            DefaultResponseContentType = new Dictionary<string, ICollection<ContentTypeWithSchema>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["200"] = [new ContentTypeWithSchema("application/json")]
+            }
+        };
+
+        _ = host.AddMapRoute(options, async context =>
+        {
+            await context.Response.WriteResponseAsync(new { message = "hello" }, StatusCodes.Status200OK);
+        }, out _);
+    }
+
+    private static void AddItemRoute(KestrunHost host)
+    {
+        var options = new MapRouteOptions
+        {
+            Pattern = "/items/{id}",
+            HttpVerbs = [HttpVerb.Post],
+            ScriptCode = new LanguageOptions { Language = ScriptLanguage.Native },
+            HandlerName = "Invoke-CreateItem",
+            AllowedRequestContentTypes = ["application/json"],
+            DefaultResponseContentType = new Dictionary<string, ICollection<ContentTypeWithSchema>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["200"] = [new ContentTypeWithSchema("application/json")]
+            },
+            IsOpenApiAnnotatedFunctionRoute = true
+        };
+
+        options.OpenAPI[HttpVerb.Post] = new OpenAPIPathMetadata(options)
+        {
+            Pattern = options.Pattern,
+            Summary = "Create item",
+            Description = "Creates an item and echoes the identifier.",
+            OperationId = "createItem",
+            Tags = ["items"],
+            RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Content = new Dictionary<string, IOpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = CreateRequestSchema()
+                    }
+                }
+            },
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse
+                {
+                    Description = "Created",
+                    Content = new Dictionary<string, IOpenApiMediaType>
+                    {
+                        ["application/json"] = new OpenApiMediaType
+                        {
+                            Schema = CreateResponseSchema()
+                        }
+                    }
+                }
+            }
+        };
+
+        _ = host.AddMapRoute(options, async context =>
+        {
+            var routeId = context.HttpContext.Request.RouteValues["id"]?.ToString();
+            context.Response.Headers["Set-Cookie"] = "session=super-secret";
+            await context.Response.WriteResponseAsync(
+                new
+                {
+                    itemId = int.Parse(routeId ?? "0", System.Globalization.CultureInfo.InvariantCulture),
+                    name = "widget"
+                },
+                StatusCodes.Status200OK);
+        }, out _);
+    }
+
+    private static IKestrunRequestInvoker CreateInvoker(bool enabled, params string[] allowedPaths)
+    {
+        var validator = new KestrunRequestValidator(new KestrunRouteInspector());
+        return new KestrunRequestInvoker(
+            validator,
+            new KestrunRequestInvokerOptions
+            {
+                EnableInvocation = enabled,
+                AllowedPathPatterns = allowedPaths
+            });
+    }
+
+    private static OpenApiSchema CreateRequestSchema()
+    {
+        return new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Required = new SortedSet<string>(StringComparer.Ordinal) { "name" },
+            Properties = new Dictionary<string, IOpenApiSchema>(StringComparer.Ordinal)
+            {
+                ["name"] = new OpenApiSchema { Type = JsonSchemaType.String }
+            }
+        };
+    }
+
+    private static OpenApiSchema CreateResponseSchema()
+    {
+        return new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Required = new SortedSet<string>(StringComparer.Ordinal) { "itemId", "name" },
+            Properties = new Dictionary<string, IOpenApiSchema>(StringComparer.Ordinal)
+            {
+                ["itemId"] = new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int32" },
+                ["name"] = new OpenApiSchema { Type = JsonSchemaType.String }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new stdio-based `Kestrun.Mcp` host plus reusable MCP-facing inspection services in core Kestrun.

This PR introduces support for:

- route discovery
- route lookup with OpenAPI-derived schema details
- OpenAPI document retrieval
- runtime inspection
- request validation
- gated safe route invocation through the normal Kestrun HTTP pipeline

Closes #393.

## What Changed
- Added a new `src/CSharp/Kestrun.Mcp` project using the official C# MCP SDK over stdio transport.
- Added reusable MCP adapters under `src/CSharp/Kestrun/Mcp`.
- Extended route metadata so MCP inspection can report bound handler names.
- Exposed runtime listener URLs from `KestrunHost` for local invocation/introspection.
- Registered native routes in Kestrun's route source-of-truth so MCP inspection sees them consistently.
- Added integration tests for route discovery, OpenAPI retrieval, validation outcomes, and route invocation.
- Added a guide page and two runnable PowerShell examples.

## Validation
- `dotnet build src/CSharp/Kestrun.Mcp/Kestrun.Mcp.csproj`
- `dotnet test tests/CSharp.Tests/Kestrun.Tests/Kestrun.Tests.csproj -f net10.0 --filter Category=Mcp`
- `Invoke-Build Restore; Invoke-Build Build`

## Notes
- `Invoke-Build Test` still surfaces unrelated existing PowerShell failures in certificate/authentication areas that were already present outside this MCP work.
- `Kestrun.Mcp` currently restores with NU1903 warnings from transitive `System.Security.Cryptography.Xml 10.0.5` via `Microsoft.PowerShell.SDK`.

## Follow-up
- Decide how `Kestrun.Mcp` should be packaged/distributed alongside the PowerShell module.
- Consider future MCP resources/prompts once the initial tool surface settles.