### PR TITLE
[codex] Fix tutorial startup readiness race

### DIFF
--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-13.1-Server-Limits.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-13.1-Server-Limits.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
 Describe 'Example 13.1-Server-Limits' {
     BeforeAll {
         $script:instance = Start-ExampleScript -Name '13.1-Server-Limits.ps1' -SkipPortProbe
+        Wait-ExampleRoute -Instance $script:instance -Route '/online' -TimeoutSeconds 20 | Out-Null
     }
     AfterAll { if ($script:instance) {
             # Stop the example script

--- a/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-14.1-Start-Stop.Tests.ps1
+++ b/tests/PowerShell.Tests/Kestrun.Tests/Tutorial/Tutorial-14.1-Start-Stop.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
 Describe 'Example 14.1-Start-Stop' -Tag 'Tutorial', 'Slow' {
     BeforeAll {
         $script:instance = Start-ExampleScript -Name '14.1-Start-Stop.ps1' -SkipPortProbe
+        Wait-ExampleRoute -Instance $script:instance -Route '/online' -TimeoutSeconds 20 | Out-Null
     }
     AfterAll { if ($script:instance) {
             # Stop the example script


### PR DESCRIPTION
## Summary

Fixes #397.

- Keep `-SkipPortProbe` for the affected TCP-based tutorial tests to avoid the generic `localhost` startup probe.
- Add an explicit `Wait-ExampleRoute` check against the injected `/online` route before test assertions run.
- Leave the Unix socket tutorial behavior unchanged because it cannot use the TCP readiness probe and already polls the Unix socket directly.

## Root Cause

These tests were marking examples as ready immediately, then sending HTTP requests before the child Kestrun process had necessarily bound its listener. Switching directly to the generic startup probe exposed another edge case: some examples bind to `127.0.0.1`, while the generic probe uses `localhost`; on environments where that resolves differently, the probe can wait until timeout or interfere with low connection-limit examples.

The targeted fix keeps startup non-blocking but waits for `/online` using the existing route polling helper, which targets `127.0.0.1`.

## Validation

- `Invoke-Pester -Path .\tests\PowerShell.Tests\Kestrun.Tests\Tutorial\Tutorial-13.1-Server-Limits.Tests.ps1, .\tests\PowerShell.Tests\Kestrun.Tests\Tutorial\Tutorial-14.1-Start-Stop.Tests.ps1`
- Result: 3 passed, 0 failed.